### PR TITLE
Added option to pass language parameter to tesseract for non-English OCR documents

### DIFF
--- a/textract/parsers/image.py
+++ b/textract/parsers/image.py
@@ -11,11 +11,17 @@ class Parser(ShellParser):
 
     def extract(self, filename, **kwargs):
 
+        #if language given as argument, specify language for tesseract to use
+        if 'language' in kwargs:
+            lang = '-l %s' % kwargs['language']
+        else:
+            lang = ''
+
         # Tesseract can't output to console directly so you must first create
         # a dummy file to write to, read, and then delete
         devnull = os.devnull
         command = (
-            'tesseract "%(filename)s" {0} > %(devnull)s && '
+            'tesseract "%(filename)s" %(lang)s {0} > %(devnull)s && '
             'cat {0}.txt && '
             'rm -f {0} {0}.txt'
         )

--- a/textract/parsers/pdf_parser.py
+++ b/textract/parsers/pdf_parser.py
@@ -28,7 +28,7 @@ class Parser(ShellParser):
         elif method == 'pdfminer':
             return self.extract_pdfminer(filename)
         elif method == 'tesseract':
-            return self.extract_tesseract(filename)
+            return self.extract_tesseract(filename, **kwargs)
         else:
             raise UnknownMethod(method)
 
@@ -42,7 +42,8 @@ class Parser(ShellParser):
         stdout, _ = self.run('pdf2txt.py "%(filename)s"' % locals())
         return stdout
 
-    def extract_tesseract(self, filename):
+    def extract_tesseract(self, filename, **kwargs):
+
         """Extract text from pdfs using tesseract (per-page OCR)."""
         temp_dir = mkdtemp()
         base = os.path.join(temp_dir, 'conv')
@@ -51,6 +52,6 @@ class Parser(ShellParser):
         contents = []
         for page in os.listdir(temp_dir):
             page_path = os.path.join(temp_dir, page)
-            page_content = TesseractParser().extract(page_path)
+            page_content = TesseractParser().extract(page_path, **kwargs)
             contents.append(page_content)
         return '\n\n'.join(contents)


### PR DESCRIPTION
Useful for extracting text from non-English documents. If keyword argument ‘language’ is specified to pdf parser, then the image parser uses this when triggering tesseract. Tesseract language data can be downloaded from here https://code.google.com/p/tesseract-ocr/downloads/list

Example use:
```
from textract.parsers.pdf_parser import Parser
norwegian_text = Parser().extract('scanned_nor.pdf', method='tesseract', language='nor')
```