### PR TITLE
Extract table contents from docx

### DIFF
--- a/textract/parsers/docx_parser.py
+++ b/textract/parsers/docx_parser.py
@@ -25,7 +25,7 @@ class Parser(BaseParser):
     def _parse_table(self, table, text):
         for row in table.rows:
             for cell in row.cells:
-                # For every cell in every row of the table, extract text from 
+                # For every cell in every row of the table, extract text from
                 # child paragraphs.
                 text += '\n\n'.join([
                     paragraph.text for paragraph in cell

--- a/textract/parsers/docx_parser.py
+++ b/textract/parsers/docx_parser.py
@@ -4,34 +4,34 @@ from .utils import BaseParser
 
 
 class Parser(BaseParser):
-    """Extract text from docx file using python-docx.
-    """
+	"""Extract text from docx file using python-docx.
+	"""
 
-    def extract(self, filename, **kwargs):
-        text = ""
-        document = docx.Document(filename)
-        
-        # Extract text from root paragraphs
-        text += '\n\n'.join([
-            paragraph.text for paragraph in document.paragraphs
-        ])
-        
-        # Recursively extract text from root tables
-	for table in document.tables:
-		text += self._parse_table(table, text)
-		
-	return text
-        
-    def _parse_table(self, table, text):
-    	for row in table.rows:
-    		for cell in row.cells:
-    		    # For every cell in every row of the table, extract text from child paragraphs
-                text += '\n\n'.join([
-                    paragraph.text for paragraph in cell
-                ])
-                
-                # Then recursively extract text from child tables
-    			for table in cell.tables:
-    				text += _parse_table(table, text)
-    				
-    	return text
+	def extract(self, filename, **kwargs):
+		text = ""
+		document = docx.Document(filename)
+
+		# Extract text from root paragraphs
+		text += '\n\n'.join([
+			paragraph.text for paragraph in document.paragraphs
+		])
+
+		# Recursively extract text from root tables
+		for table in document.tables:
+			text += self._parse_table(table, text)
+
+		return text
+
+	def _parse_table(self, table, text):
+		for row in table.rows:
+			for cell in row.cells:
+				# For every cell in every row of the table, extract text from child paragraphs
+				text += '\n\n'.join([
+					paragraph.text for paragraph in cell
+				])
+
+				# Then recursively extract text from child tables
+				for table in cell.tables:
+					text += _parse_table(table, text)
+
+		return text

--- a/textract/parsers/docx_parser.py
+++ b/textract/parsers/docx_parser.py
@@ -4,34 +4,34 @@ from .utils import BaseParser
 
 
 class Parser(BaseParser):
-	"""Extract text from docx file using python-docx.
-	"""
+    """Extract text from docx file using python-docx.
+    """
 
-	def extract(self, filename, **kwargs):
-		text = ""
-		document = docx.Document(filename)
+    def extract(self, filename, **kwargs):
+        text = ""
+        document = docx.Document(filename)
 
-		# Extract text from root paragraphs
-		text += '\n\n'.join([
-			paragraph.text for paragraph in document.paragraphs
-		])
+        # Extract text from root paragraphs
+        text += '\n\n'.join([
+            paragraph.text for paragraph in document.paragraphs
+        ])
 
-		# Recursively extract text from root tables
-		for table in document.tables:
-			text += self._parse_table(table, text)
+        # Recursively extract text from root tables
+        for table in document.tables:
+            text += self._parse_table(table, text)
 
-		return text
+        return text
 
-	def _parse_table(self, table, text):
-		for row in table.rows:
-			for cell in row.cells:
-				# For every cell in every row of the table, extract text from child paragraphs
-				text += '\n\n'.join([
-					paragraph.text for paragraph in cell
-				])
+    def _parse_table(self, table, text):
+        for row in table.rows:
+            for cell in row.cells:
+                # For every cell in every row of the table, extract text from child paragraphs
+                text += '\n\n'.join([
+                    paragraph.text for paragraph in cell
+                ])
 
-				# Then recursively extract text from child tables
-				for table in cell.tables:
-					text += _parse_table(table, text)
+                # Then recursively extract text from child tables
+                for table in cell.tables:
+                    text += _parse_table(table, text)
 
-		return text
+        return text

--- a/textract/parsers/docx_parser.py
+++ b/textract/parsers/docx_parser.py
@@ -11,12 +11,12 @@ class Parser(BaseParser):
         text = ""
         document = docx.Document(filename)
 
-        # Extract text from root paragraphs
+        # Extract text from root paragraphs.
         text += '\n\n'.join([
             paragraph.text for paragraph in document.paragraphs
         ])
 
-        # Recursively extract text from root tables
+        # Recursively extract text from root tables.
         for table in document.tables:
             text += self._parse_table(table, text)
 
@@ -25,12 +25,13 @@ class Parser(BaseParser):
     def _parse_table(self, table, text):
         for row in table.rows:
             for cell in row.cells:
-                # For every cell in every row of the table, extract text from child paragraphs
+                # For every cell in every row of the table, extract text from 
+                # child paragraphs.
                 text += '\n\n'.join([
                     paragraph.text for paragraph in cell
                 ])
 
-                # Then recursively extract text from child tables
+                # Then recursively extract text from child tables.
                 for table in cell.tables:
                     text += _parse_table(table, text)
 

--- a/textract/parsers/docx_parser.py
+++ b/textract/parsers/docx_parser.py
@@ -8,7 +8,30 @@ class Parser(BaseParser):
     """
 
     def extract(self, filename, **kwargs):
+        text = ""
         document = docx.Document(filename)
-        return '\n\n'.join([
+        
+        # Extract text from root paragraphs
+        text += '\n\n'.join([
             paragraph.text for paragraph in document.paragraphs
         ])
+        
+        # Recursively extract text from root tables
+		for table in document.tables:
+			text += self._parse_table(table, text)
+			
+		return text
+        
+    def _parse_table(self, table, text):
+    	for row in table.rows:
+    		for cell in row.cells:
+    		    # For every cell in every row of the table, extract text from child paragraphs
+                text += '\n\n'.join([
+                    paragraph.text for paragraph in cell
+                ])
+                
+                # Then recursively extract text from child tables
+    			for table in cell.tables:
+    				text += _parse_table(table, text)
+    				
+    	return text

--- a/textract/parsers/docx_parser.py
+++ b/textract/parsers/docx_parser.py
@@ -17,10 +17,10 @@ class Parser(BaseParser):
         ])
         
         # Recursively extract text from root tables
-		for table in document.tables:
-			text += self._parse_table(table, text)
-			
-		return text
+	for table in document.tables:
+		text += self._parse_table(table, text)
+		
+	return text
         
     def _parse_table(self, table, text):
     	for row in table.rows:


### PR DESCRIPTION
Many Microsoft Word documents utilize tables for page organization and formatting.  In the previous implementation of docx_parser.py, such tables were ignored even though python-docx module provides useful interface to these containers.  Documents using many of the templates provided by Microsoft Word contain almost all of their content within a hidden table.  This would result in many seemingly full length documents to be parsed as empty strings.

The proposed revision recursively explores the table structure of the document and extracts all paragraphs contained therein, resulting in a far more thorough and flexible parser.