### PR TITLE
pdftotext: option to preserve layout

### DIFF
--- a/textract/parsers/pdf_parser.py
+++ b/textract/parsers/pdf_parser.py
@@ -16,7 +16,7 @@ class Parser(ShellParser):
     def extract(self, filename, method='', **kwargs):
         if method == '' or method == 'pdftotext':
             try:
-                return self.extract_pdftotext(filename)
+                return self.extract_pdftotext(filename, **kwargs)
             except ShellError as ex:
                 # If pdftotext isn't installed and the pdftotext method
                 # wasn't specified, then gracefully fallback to using
@@ -33,9 +33,13 @@ class Parser(ShellParser):
         else:
             raise UnknownMethod(method)
 
-    def extract_pdftotext(self, filename):
+    def extract_pdftotext(self, filename, **kwargs):
         """Extract text from pdfs using the pdftotext command line utility."""
-        stdout, _ = self.run('pdftotext "%(filename)s" -' % locals())
+        if 'layout' in kwargs:
+            layout = '-layout'
+        else:
+            layout = ''
+        stdout, _ = self.run('pdftotext %(layout)s "%(filename)s" -' % locals())
         return stdout
 
     def extract_pdfminer(self, filename):


### PR DESCRIPTION
The default pdf to text parser (pdftotext) don't preserver the layout. I added an extra argument (-layout) to do so. How to use:

from python:
import textract
textract.process("file.pdf") #without layout
textract.process("file.pdf", layout=True) #with layout

from CLI utility:
textract "file.pdf" #without layout
textract -O layout=True "file.pdf" #with layout

Note: the actual value of variable layout do not matter. It can be anything. 