### PR TITLE
extracting text from hyperlink for .docx files

### DIFF
--- a/textract/parsers/docx_parser.py
+++ b/textract/parsers/docx_parser.py
@@ -1,4 +1,10 @@
 import docx
+import os
+import re
+import shutil
+import zipfile
+from tempfile import mkdtemp
+from StringIO import StringIO
 
 from .utils import BaseParser
 
@@ -9,7 +15,8 @@ class Parser(BaseParser):
 
     def extract(self, filename, **kwargs):
         text = ""
-        document = docx.Document(filename)
+        file_obj = self._remove_hyperlink_tags(filename)
+        document = docx.Document(file_obj)
 
         # Extract text from root paragraphs.
         text += '\n\n'.join([
@@ -36,3 +43,40 @@ class Parser(BaseParser):
                     text += self._parse_table(table)
 
         return text
+
+    def _remove_hyperlink_tags(self, filename):
+        # python-docx don't extract text within hyperlinks
+        # issue: https://github.com/python-openxml/python-docx/issues/85
+        # this is work around to fetch the text within hyperlinks
+        # it replaces the hyperlink tags with empty string in the document.xml
+        # and returns the file-like obj (StringIO) of the new docx
+
+        # unzip the docx into a temp directory
+        temp_dir = mkdtemp()
+        with zipfile.ZipFile(filename) as zipf:
+            zipf.extractall(temp_dir)
+
+        # remove the hyperlink tags from the word/document.xml file
+        xml_doc = os.path.join(temp_dir, "word", "document.xml")
+
+        if os.path.isfile(xml_doc):
+            with open(xml_doc) as f:
+                xml = f.read()
+                xml = xml.replace('</w:hyperlink>', '')
+                xml = re.sub('<w:hyperlink[^>]*>', '', xml)
+
+            with open(xml_doc, 'w') as f:
+                f.write(xml)
+
+        # zip back all the files into file-like obj
+        file_obj = StringIO()
+        zipf = zipfile.ZipFile(file_obj, "w")
+        for root, _, fnames in os.walk(temp_dir):
+            for fname in fnames:
+                file_path = os.path.join(root, fname)
+                rel_path = os.path.relpath(file_path, temp_dir)
+                zipf.write(file_path, arcname=rel_path)
+
+        shutil.rmtree(temp_dir)
+
+        return file_obj


### PR DESCRIPTION
python-docx don't extract text from the hyperlinks as discussed in https://github.com/python-openxml/python-docx/issues/85. I added an workaround so that textract can still extract this text by removing the hyperlink tag from the xml. 

You can download a test docx file from [here](https://github.com/ankushshah89/textract/blob/2f4ff663643526e0594c307b9c0f40b808638b4e/tests/docx/hyperlink_text.docx?raw=true)

before workaround
textract hyperlink_text.docx # outputs "My email address is "

after workaround
textract hyperlink_text.docx # outputs " My email address is python@gmail.com" 
