### PR TITLE
Support for image OCR on Windows

### DIFF
--- a/textract/parsers/image.py
+++ b/textract/parsers/image.py
@@ -2,6 +2,7 @@
 Process an image file using tesseract.
 """
 import os
+import platform
 
 from .utils import ShellParser
 
@@ -20,11 +21,18 @@ class Parser(ShellParser):
         # Tesseract can't output to console directly so you must first create
         # a dummy file to write to, read, and then delete
         devnull = os.devnull
-        command = (
-            'tesseract "%(filename)s" %(lang)s {0} > %(devnull)s && '
-            'cat {0}.txt && '
-            'rm -f {0} {0}.txt'
-        )
+        if platform.system().lower() == 'windows':
+            command = (
+                'tesseract "%(filename)s" %(lang)s {0} > %(devnull)s && '
+                'type {0}.txt && '
+                'del /f {0} {0}.txt'
+            )
+        else:
+            command = (
+                'tesseract "%(filename)s" %(lang)s {0} > %(devnull)s && '
+                'cat {0}.txt && '
+                'rm -f {0} {0}.txt'
+            )
         temp_filename = self.temp_filename()
         stdout, _ = self.run(command.format(temp_filename) % locals())
         return stdout


### PR DESCRIPTION
On Windows platform, uses Windows equivalents of Linux shell commands: "type" instead of "cat" and "del" instead of "rm".

Fixes this bug:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Python27\lib\site-packages\textract\parsers\__init__.py", line 57, in process
    return parser.process(filename, encoding, **kwargs)
  File "C:\Python27\lib\site-packages\textract\parsers\utils.py", line 44, in process
    byte_string = self.extract(filename, **kwargs)
  File "C:\Python27\lib\site-packages\textract\parsers\image.py", line 29, in extract
    stdout, _ = self.run(command.format(temp_filename) % locals())
  File "C:\Python27\lib\site-packages\textract\parsers\utils.py", line 92, in run
    command, pipe.returncode, stdout, stderr,
textract.exceptions.ShellError: The command `tesseract "H:\scan\img122.tiff"  c:\users\onionradish\appdata\local\temp\tmptcdqqv > nul && cat c:\users\onionradish\appdata\local\temp\tmptcdqqv.txt && rm -f c:\users\onionradish\appdata\local\temp\tmptcdqqv c:\users\onionradish\appdata\local\temp\tmptcdqqv.txt` failed with exit code 1
```
