### PR TITLE
Add .TIF extension synonym

### DIFF
--- a/textract/parsers/__init__.py
+++ b/textract/parsers/__init__.py
@@ -12,6 +12,7 @@ EXTENSION_SYNONYMS = {
     ".jpeg": ".jpg",
     ".htm": ".html",
     "": ".txt",
+    ".tif": ".tiff",
 }
 
 # default encoding that is returned by the process method. specify it


### PR DESCRIPTION
Add ".tif" as an extension synonym for ".tiff" files
