### PR TITLE
Python 3 install support

### DIFF
--- a/requirements/python
+++ b/requirements/python
@@ -4,7 +4,6 @@ argcomplete
 chardet
 python-pptx>=0.5.1
 python-docx
-pdfminer==20140328
 beautifulsoup4
 xlrd
 EbookLib

--- a/requirements/python
+++ b/requirements/python
@@ -4,6 +4,7 @@ argcomplete
 chardet
 python-pptx>=0.5.1
 python-docx
+pdfminer.six
 beautifulsoup4
 xlrd
 EbookLib

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,13 @@ setup(
     ],
     install_requires=dependencies,
     dependency_links=dependency_links,
+    extras_require={
+        ':python_version=="2.7" or python_version=="2.6"': [
+            'pdfminer==20140328',
+        ],
+        ':python_version=="3.5"': [
+            'pdfminer.six',
+        ],
+    },
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -44,13 +44,5 @@ setup(
     ],
     install_requires=dependencies,
     dependency_links=dependency_links,
-    extras_require={
-        ':python_version=="2.7" or python_version=="2.6"': [
-            'pdfminer==20140328',
-        ],
-        ':python_version=="3.5"': [
-            'pdfminer.six',
-        ],
-    },
     zip_safe=False,
 )


### PR DESCRIPTION
These two commits represent my thought process as I was working to get textract to build on Python 3. First, I sought to use the classic pdfminer package to build on Python 2 without changing the dependencies. But then I realized that pdfminer.six works on Python 2 and Python 3, so why not simply require it. The result is a simple dependency change that allows textract to install and import on Python 3. While there are almost certainly outstanding issues with other aspects of the package on Python 3 as seen by other pending pull requests, this one takes a very modest approach, only making one minor change toward compatibility.
