### PR TITLE
Pillow fails installation on precise without libjpeg-dev

### DIFF
--- a/requirements/debian
+++ b/requirements/debian
@@ -12,6 +12,7 @@ unrtf
 
 # parse image files
 tesseract-ocr
+libjpeg-dev
 
 # parse pdfs
 poppler-utils


### PR DESCRIPTION
I'm in the process of working on a more substantial PR, but I noticed the vagrant environment failed proper setup because it was missing libjpeg-dev. Not sure if this is somehow unique to me or not (shouldn't be, since I'm building on the VM image).

So, this simply adds the package name to the debian requirements file.
