### PR TITLE
Check for importability, rather than presence of file

### DIFF
--- a/textract/parsers/__init__.py
+++ b/textract/parsers/__init__.py
@@ -44,15 +44,16 @@ def process(filename, encoding=DEFAULT_ENCODING, **kwargs):
     # (e.g. python's json module), all extension parser modules have
     # the _parser extension
     rel_module = ext + '_parser'
-    module_name = rel_module[1:]
 
-    # if this module name doesn't exist in this directory it isn't
-    # currently supported
-    this_dir = os.path.dirname(os.path.abspath(__file__))
-    if not os.path.exists(os.path.join(this_dir, module_name + '.py')):
+    # If we can't import the module, the file extension isn't currently
+    # supported
+    try:
+        filetype_module = importlib.import_module(
+            rel_module, 'textract.parsers')
+    except ImportError:
         raise exceptions.ExtensionNotSupported(ext)
 
     # do the extraction
-    filetype_module = importlib.import_module(rel_module, 'textract.parsers')
+
     parser = filetype_module.Parser()
     return parser.process(filename, encoding, **kwargs)


### PR DESCRIPTION
This makes the implementation of checking extension support a bit
more robust. The old mechanism checked for the presence of
"extension_parser.py" in the same directory as the __init__.py. This
works in a lot of cases, but can fail in cases where the module
actually could have been imported. Simply trying to import the module
and raising an exception if it can't be imported should cover off the
other corner cases.

For a couple of examples of those corner cases: In my case I'm shipping
my code to an environment that is pretty constrained in terms of storage.
As a result, my build scripts strip out the ".py" flies and ship only the
".pyc" files. The existing code claims it can't support any extensions,
because the ".py" file is absent, even though the ".pyc" file would enable
it to function properly.

The other scenario I can think of is import hooks. See:

https://www.python.org/dev/peps/pep-0302/

Import hooks might be used to import modules from zip files, remote locations,
or other non-traditional sources. Checking the importability of a parser
module is compatible with all of these, while checking the presence
of a file is not.