### PR TITLE
Fix ShellError.is_not_installed()

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+import unittest
+from uuid import uuid4
+
+from textract.parsers import utils
+from textract.parsers import exceptions
+
+
+class UtilsTestCase(unittest.TestCase):
+    def test_shell_parser_run(self):
+        parser = utils.ShellParser()
+        try:
+            # There shouldn't be a command on the path matching a random uuid
+            parser.run([str(uuid4())])
+        except exceptions.ShellError as e:
+            self.assertTrue(e.is_not_installed())
+        else:
+            self.assertTrue(False, "Expected ShellError")


### PR DESCRIPTION
ShellError.is_not_installed() was broken in ce7bc0ecde56c12a908aae7e454a0fa03236d911
when it stopped running Popen with the "shell=True" argument. Since
it wasn't being run through a shell, it was throwing an OSError instead
of running but exiting with an exit code 127.

This is a minimal change so that the ShellError will still work the
same as before, but if we get an OSError we pass in the 127 exit code.
This way if there are still any scenarios where exit code 127 would
be run by the application, it will still work as before.