### PR TITLE
avoid unicode decode error with html_parser

### DIFF
--- a/textract/parsers/html_parser.py
+++ b/textract/parsers/html_parser.py
@@ -125,7 +125,7 @@ class Parser(BaseParser):
         return soup
 
     def extract(self, filename, **kwargs):
-        with open(filename) as stream:
+        with open(filename, "rb") as stream:
             soup = BeautifulSoup(stream, 'lxml')
 
         # Convert tables to ASCII ones


### PR DESCRIPTION
Html parser currently assumes UTF8 encoding of html files. BeautifulSoup handles byte streams, and can therefore be trusted to parse html files in strange encodings by giving it a bytestream instead of a text stream, and then decoding using BaseParser.process in the end.