### PR TITLE
docs broken for v1.6.0

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -7,5 +7,7 @@ requirements:
       updates: all
   - requirements/python-dev:
       updates: all
+  - requirements/python+compile:
+      updates: all
 assignees:
   - deanmalmgren

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,10 @@ latest changes in development for next release
 
 .. THANKS FOR CONTRIBUTING; ADD YOUR UNRELEASED CHANGES HERE!
 
+* several bug fixes, including:
+
+  * fixing the readthedocs build (`#150`_)
+
 
 1.6.0
 -------------------
@@ -341,3 +345,4 @@ latest changes in development for next release
 .. _#147: https://github.com/deanmalmgren/textract/issues/147
 .. _#148: https://github.com/deanmalmgren/textract/issues/148
 .. _#149: https://github.com/deanmalmgren/textract/issues/149
+.. _#150: https://github.com/deanmalmgren/textract/issues/150

--- a/provision/python.sh
+++ b/provision/python.sh
@@ -12,7 +12,7 @@ fi
 pip install -U pip
 
 # Install the requirements for this package as well as this module.
-pip install -r requirements/python
+pip install -r requirements/python+compile
 pip install .
 
 # Install the requirements for this package in development

--- a/requirements/python
+++ b/requirements/python
@@ -1,5 +1,3 @@
-# This file contains all python dependencies that are required by the
-# textract package in order for it to properly work
 argcomplete==1.8.2
 chardet==2.3.0
 python-pptx==0.6.5
@@ -9,7 +7,6 @@ docx2txt==0.6
 beautifulsoup4==4.5.3
 xlrd==1.0.0
 EbookLib==0.15
-pocketsphinx==0.1.3
 SpeechRecognition==3.6.3
 https://github.com/mattgwwalker/msg-extractor/zipball/master
 six==1.10.0

--- a/requirements/python+compile
+++ b/requirements/python+compile
@@ -1,0 +1,10 @@
+# This file contains all python dependencies that are required by the textract
+# package in order for it to properly work. As much as possible, these
+# dependencies should be placed in requirements/python. Things that are
+# separately listed in this file are NOT included in the readthedocs build
+-r python
+
+# pocketsphinx causes an issue when being built on readthedocs
+# https://github.com/deanmalmgren/textract/issues/150
+# http://bit.ly/2pcPre5
+pocketsphinx==0.1.3

--- a/requirements/python-dev
+++ b/requirements/python-dev
@@ -1,7 +1,3 @@
-# install everything in the python requirements too. this may be
-# needed by readthedocs?!?!
--r python
-
 # needed for tests/run.py script to read .travis.yml file
 PyYAML==3.12
 pep8==1.7.0

--- a/requirements/python-doc
+++ b/requirements/python-doc
@@ -1,0 +1,5 @@
+# install everything that is required for the documentation build on
+# readthedocs
+
+-r python
+-r python-dev

--- a/setup.py
+++ b/setup.py
@@ -14,22 +14,31 @@ with open("README.rst") as stream:
 
 github_url = 'https://github.com/deanmalmgren/textract'
 
-# read in the dependencies from the requirements files
-dependencies, dependency_links = [], []
-filenames = [
-    os.path.join("requirements", "python"),
-    os.path.join("requirements", "python+compile"),
-]
-for filename in filenames:
-    with open(filename, 'r') as stream:
+
+def parse_requirements(requirements_filename):
+    """read in the dependencies from the requirements files
+    """
+    dependencies, dependency_links = [], []
+    requirements_dir = os.path.dirname(requirements_filename)
+    with open(requirements_filename, 'r') as stream:
         for line in stream:
             line = line.strip()
-            if line.startswith("http"):
+            if line.startswith("-r"):
+                filename = os.path.join(requirements_dir, line[2:].strip())
+                _dependencies, _dependency_links = parse_requirements(filename)
+                dependencies.extend(_dependencies)
+                dependency_links.extend(_dependency_links)
+            elif line.startswith("http"):
                 dependency_links.append(line)
             else:
                 package = line.split('#')[0]
                 if package:
                     dependencies.append(package)
+    return dependencies, dependency_links
+
+
+requirements_filename = os.path.join("requirements", "python+compile")
+dependencies, dependency_links = parse_requirements(requirements_filename)
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -14,18 +14,22 @@ with open("README.rst") as stream:
 
 github_url = 'https://github.com/deanmalmgren/textract'
 
-# read in the dependencies from the virtualenv requirements file
+# read in the dependencies from the requirements files
 dependencies, dependency_links = [], []
-filename = os.path.join("requirements", "python")
-with open(filename, 'r') as stream:
-    for line in stream:
-        line = line.strip()
-        if line.startswith("http"):
-            dependency_links.append(line)
-        else:
-            package = line.split('#')[0]
-            if package:
-                dependencies.append(package)
+filenames = [
+    os.path.join("requirements", "python"),
+    os.path.join("requirements", "python+compile"),
+]
+for filename in filenames:
+    with open(filename, 'r') as stream:
+        for line in stream:
+            line = line.strip()
+            if line.startswith("http"):
+                dependency_links.append(line)
+            else:
+                package = line.split('#')[0]
+                if package:
+                    dependencies.append(package)
 
 
 setup(


### PR DESCRIPTION
It looks like [the documentation has not been building on readthedocs](https://readthedocs.org/projects/textract/builds/5238871/) since we merged in #122. It looks like readthedocs is trying to build a wheel for pocketsphinx and failing because `swig` isn't installed on their build servers. Any ideas what to do here @barrust?

The traceback looks like:

```
Building wheels for collected packages: pocketsphinx
  Running setup.py bdist_wheel for pocketsphinx: started
  Running setup.py bdist_wheel for pocketsphinx: finished with status 'error'
  Complete output from command /home/docs/checkouts/readthedocs.org/user_builds/textract/envs/v1.6.0/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-yHiy50/pocketsphinx/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpnhbraQpip-wheel- --python-tag cp27:
  running bdist_wheel
  running build_ext
  building 'sphinxbase._ad' extension
  swigging swig/sphinxbase/ad.i to swig/sphinxbase/ad_wrap.c
  swig -python -modern -Ideps/sphinxbase/include -Ideps/sphinxbase/include/sphinxbase -Ideps/sphinxbase/include/android -Ideps/sphinxbase/swig -outdir sphinxbase -o swig/sphinxbase/ad_wrap.c swig/sphinxbase/ad.i
  unable to execute 'swig': No such file or directory
  error: command 'swig' failed with exit status 1
  
  ----------------------------------------
  Failed building wheel for pocketsphinx
  Running setup.py clean for pocketsphinx
Failed to build pocketsphinx
Installing collected packages: argcomplete, XlsxWriter, python-pptx, pdfminer.six, docx2txt, beautifulsoup4, xlrd, EbookLib, pocketsphinx, SpeechRecognition, pep8, coverage, docopt, coveralls, sphinx-argparse, bumpversion, olefile, ExtractMsg
  Running setup.py install for pdfminer.six: started
    Running setup.py install for pdfminer.six: finished with status 'done'
  Found existing installation: beautifulsoup4 4.4.1
    Not uninstalling beautifulsoup4 at /usr/lib/python2.7/dist-packages, outside environment /home/docs/checkouts/readthedocs.org/user_builds/textract/envs/v1.6.0
  Found existing installation: xlrd 0.9.4
    Not uninstalling xlrd at /usr/lib/python2.7/dist-packages, outside environment /home/docs/checkouts/readthedocs.org/user_builds/textract/envs/v1.6.0
  Running setup.py install for pocketsphinx: started
    Running setup.py install for pocketsphinx: finished with status 'error'
    Complete output from command /home/docs/checkouts/readthedocs.org/user_builds/textract/envs/v1.6.0/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-yHiy50/pocketsphinx/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-aUUoMf-record/install-record.txt --single-version-externally-managed --compile --install-headers /home/docs/checkouts/readthedocs.org/user_builds/textract/envs/v1.6.0/include/site/python2.7/pocketsphinx:
    running install
    running build_ext
    building 'sphinxbase._ad' extension
    swigging swig/sphinxbase/ad.i to swig/sphinxbase/ad_wrap.c
    swig -python -modern -Ideps/sphinxbase/include -Ideps/sphinxbase/include/sphinxbase -Ideps/sphinxbase/include/android -Ideps/sphinxbase/swig -outdir sphinxbase -o swig/sphinxbase/ad_wrap.c swig/sphinxbase/ad.i
    unable to execute 'swig': No such file or directory
    error: command 'swig' failed with exit status 1
    
    ----------------------------------------
Command "/home/docs/checkouts/readthedocs.org/user_builds/textract/envs/v1.6.0/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-yHiy50/pocketsphinx/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-aUUoMf-record/install-record.txt --single-version-externally-managed --compile --install-headers /home/docs/checkouts/readthedocs.org/user_builds/textract/envs/v1.6.0/include/site/python2.7/pocketsphinx" failed with error code 1 in /tmp/pip-build-yHiy50/pocketsphinx/
```