### PR TITLE
require swig only when needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import glob
 import os
-import sys
+import subprocess
 from setuptools import setup
 
 import textract
@@ -40,6 +40,13 @@ def parse_requirements(requirements_filename):
 requirements_filename = os.path.join("requirements", "python")
 dependencies, dependency_links = parse_requirements(requirements_filename)
 
+try:
+    subprocess.call(["swig", "-version"])
+except OSError:
+    # swig is required by pocketsphinx which is used in some cases for the audio extract feature
+    # if it's not installed, we remove the pocketsphinx dependency
+    # that way only when you try to use the audio extract feature it will fail
+    dependencies = [d for d in dependencies if not d.startswith("pocketsphinx")]
 
 setup(
     name=textract.__name__,


### PR DESCRIPTION
### reproduction steps
* don't have swig installed (which is needed only for specific audio extract feature, see #122)
* install textract: `pip install textract`

#### expected
* install and work correctly (as long as you don't use the specific feature which requires swig)

#### actual
* swig is needed when installing textract, even if you don't intend to use it

### notes
* While I generally don't like to run code on setup.py - I think it's the best solution. Swig will run anyway when you install, so it doesn't add much overhead.
* Besides the setup.py change no other change is needed, the pocketsphinx dependency is imported by the speech recognition library only when needed. (I tested it)