### PR TITLE
Missing Dependency

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,7 +23,7 @@ package manager before installing textract from pypi.
 .. code-block:: bash
 
     apt-get install python-dev libxml2-dev libxslt1-dev antiword unrtf poppler-utils pstotext tesseract-ocr \
-    flac ffmpeg lame libmad0 libsox-fmt-mp3 sox libjpeg-dev swig
+    flac ffmpeg lame libmad0 libsox-fmt-mp3 sox libjpeg-dev swig libpulse-dev
     pip install textract
 
 .. note::


### PR DESCRIPTION
Hey there just noticed that we are missing the dependency in the docs here for `libpulse-dev` .

Without this compiling of `pocketsphinx` fails with:
```text
deps/sphinxbase/src/libsphinxad/ad_pulse.c:44:30: fatal error: pulse/pulseaudio.h: No such file or directory
compilation terminated.
error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```
Not a big contribution but should help new users.

:beers: Cheers! :beers: