### PR TITLE
Added fake pocketsphinx provision script which allows to install without swig dependency

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,7 +36,8 @@ package manager before installing textract from pypi.
 
     Swig dependency is required by pocketsphinx which might be a problem to install in some environments.
     In that case, you can run the fake pocketsphinx provision script before installing textract.
-    E.g. :code:`provision/fake-pocketsphinx.sh && pip install textract`
+    :code:`curl https://raw.githubusercontent.com/deanmalmgren/textract/master/provision/fake-pocketsphinx.sh | bash -`
+    Then proceed to install textract: :code:`pip install textract`.
     See `issue #159 <https://github.com/deanmalmgren/textract/issues/159>`_ for details.
 
 OSX

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -32,6 +32,13 @@ package manager before installing textract from pypi.
     instances of Ubuntu. See `issue #19
     <https://github.com/deanmalmgren/textract/pull/19>`_ for details
 
+.. note::
+
+    Swig dependency is required by pocketsphinx which might be a problem to install in some environments.
+    In that case, you can run the fake pocketsphinx provision script before installing textract.
+    E.g. :code:`provision/fake-pocketsphinx.sh && pip install textract`
+    See `issue #159 <https://github.com/deanmalmgren/textract/issues/159>`_ for details.
+
 OSX
 ---
 

--- a/provision/fake-pocketsphinx.sh
+++ b/provision/fake-pocketsphinx.sh
@@ -12,9 +12,9 @@
 # TEMPDIR is used as the fake pocketsphinx package directory, it will be removed
 TEMPDIR=`mktemp -d`
 
-# fake pocketsphinx version, we get it from requirements files
-VERSION="${FAKE_POCKETSPHINX_VERSION:-`cat requirements/* | grep 'pocketsphinx==' | cut -c15-`}"
-
+# fake pocketsphinx version
+# TODO: update the pocketsphinx dependency version automatically
+VERSION="${FAKE_POCKETSPHINX_VERSION:-0.1.3}"
 
 # create a fake setup.py and install it
 echo "from setuptools import setup; setup(\

--- a/provision/fake-pocketsphinx.sh
+++ b/provision/fake-pocketsphinx.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# the pocketsphinx dependency requires swig during pip installation
+# swig might be difficult to install in some environments
+#
+# this script install a fake pocketsphinx dependency - which allow to easily install without the swig dependency
+#
+# for more details and discussion, see:
+# * https://github.com/deanmalmgren/textract/issues/159
+# * https://github.com/deanmalmgren/textract/pull/160
+
+# TEMPDIR is used as the fake pocketsphinx package directory, it will be removed
+TEMPDIR=`mktemp -d`
+
+# fake pocketsphinx version, we get it from requirements files
+VERSION="${FAKE_POCKETSPHINX_VERSION:-`cat requirements/* | grep 'pocketsphinx==' | cut -c15-`}"
+
+
+# create a fake setup.py and install it
+echo "from setuptools import setup; setup(\
+        name='pocketsphinx', \
+        version='${VERSION}'\
+     )" > "${TEMPDIR}/setup.py"
+"${FAKE_POCKETSPHINX_PIP:-pip}" install "${TEMPDIR}/"
+
+# cleanup
+rm -rf "${TEMPDIR}"

--- a/tests/Dockerfile.no-swig
+++ b/tests/Dockerfile.no-swig
@@ -1,0 +1,11 @@
+# this Dockerfile is used to test installation of textract without swig dependency
+# see provision/fake-pocketsphinx.sh for more details
+
+# this is an existing image in Docker hub which has textract 1.5.0 installed
+FROM clue/textract:7244906dd213
+
+RUN apt-get remove swig
+RUN pip install --upgrade pip
+
+COPY provision/fake-pocketsphinx.sh /provision/fake-pocketsphinx.sh
+COPY /requirements /requirements

--- a/tests/run_no_swig_tests.sh
+++ b/tests/run_no_swig_tests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# test installation of textract without swig
+# exits with correct return code which can be used to connect to CI
+# see provision/fake-pocketsphinx.sh for more details
+
+if [ ! -f "tests/Dockerfile.no-swig" ]; then
+    echo "you should run this script from project root directory:"
+    echo "tests/run_no_swig_tests.sh"
+    exit 1
+fi
+
+if ! docker build -f "tests/Dockerfile.no-swig" . -t textract/no-swig; then
+    echo "failed to build textract/no-swig docker image"
+    exit 1
+fi
+
+# docker image has old textract version which didn't require swig
+if [ "`docker run textract/no-swig --version 2>&1`" != "textract 1.5.0" ]; then
+    echo "old textract version is not as expected: '${OLD_TEXTRACT_VERSION}'"
+    exit 1
+fi
+
+# upgrade textract to version 1.6.1
+# this is expected to fail - due to missing swig dependency
+if docker run --entrypoint bash textract/no-swig -c "pip install --upgrade textract"; then
+    echo "succeeded to install new textract without swig, and without fake pocketsphinx"
+    exit 1
+fi
+
+# use the provision/fake-pocketsphinx.sh script to install the fake pocketsphinx
+if ! docker run --entrypoint bash textract/no-swig -c "/provision/fake-pocketsphinx.sh && pip install --upgrade textract"; then
+    echo "failed to install fake pocketsphinx"
+    exit 1
+fi
+
+# TODO: add some tests here to make sure textract works correctly works without swig
+
+echo "Success!"
+exit 0


### PR DESCRIPTION
* script installs a fake pocketsphinx dependency - which then allows to install textract without swig
* the script is ubiquitous - you can run it from anywhere, e.g. directly from bash:
```
pip uninstall -y pockersphinx
curl https://raw.githubusercontent.com/OriHoch/textract/fake-pocketsphinx-for-swig-dependency/provision/fake-pocketsphinx.sh | bash -
```
* added docker test - which tests the installation of textract without swig
* this docker test can be used as a base for more installation / dependency related tests
