### PR TITLE
Prevent opening a cmd window with Popen() on Windows

### DIFF
--- a/textract/parsers/utils.py
+++ b/textract/parsers/utils.py
@@ -78,10 +78,16 @@ class ShellParser(BaseParser):
         """
 
         # run a subprocess and put the stdout and stderr on the pipe object
+        if subprocess.mswindows:
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        else:
+            startupinfo = None
         try:
             pipe = subprocess.Popen(
                 args,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                startupinfo=startupinfo,
             )
         except OSError as e:
             if e.errno == errno.ENOENT:


### PR DESCRIPTION
On Windows, when using Popen, the default behaviour opens a cmd window (that disappears as soon as the command exited). This PR prevents opening such undesired windows.