### PR TITLE
 Add .tab support as extension synonym for .tsv

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,8 @@ file types by either mentioning them on the `issue tracker
 
 * ``.csv`` via python builtins
 
+* ``.tsv`` and ``.tab`` via python builtins
+
 * ``.doc`` via `antiword`_
 
 * ``.docx`` via `python-docx2txt`_

--- a/textract/parsers/__init__.py
+++ b/textract/parsers/__init__.py
@@ -17,6 +17,7 @@ EXTENSION_SYNONYMS = {
     ".htm": ".html",
     "": ".txt",
     ".log": ".txt",
+    ".tab": ".tsv",
 }
 
 # default encoding that is returned by the process method. specify it


### PR DESCRIPTION
- Added .tab support as an extension synonym for .tsv
- Added .tsv and .tab support to the index doc