### PR TITLE
Make ebookLib optional; fixes #120

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import glob
 import os
-import sys
+
 from setuptools import setup
 
 import textract
@@ -32,7 +32,9 @@ def parse_requirements(requirements_filename):
                 dependency_links.append(line)
             else:
                 package = line.split('#')[0]
-                if package:
+                # Ebooklib is licensed under the AGPL, so it won't be installed unless
+                # explictly required through the corresponding feature
+                if package and not package.startswith("EbookLib"):
                     dependencies.append(package)
     return dependencies, dependency_links
 
@@ -58,5 +60,8 @@ setup(
     ],
     install_requires=dependencies,
     dependency_links=dependency_links,
+    extras_require={
+        'EbookLib': ["EbookLib"]
+    },
     zip_safe=False,
 )

--- a/textract/parsers/epub_parser.py
+++ b/textract/parsers/epub_parser.py
@@ -1,4 +1,3 @@
-from ebooklib import epub, ITEM_DOCUMENT
 from bs4 import BeautifulSoup
 
 from .utils import BaseParser
@@ -9,6 +8,10 @@ class Parser(BaseParser):
     """
 
     def extract(self, filename, **kwargs):
+        try:
+            from ebooklib import epub, ITEM_DOCUMENT
+        except ImportError:
+            raise ImportError("You need to install textract with the EbookLib feature to extract text from epub files")
         book = epub.read_epub(filename)
         result = ''
         for id, _ in book.spine:


### PR DESCRIPTION
Following the [fosssa guidelines](https://app.fossa.io/policies/licensing/4871), I wanted to get rid of any AGPL code from my project and therefore moved ebooklib into an optional dependency. 

EDIT: I don't know whether you want to have ebooklib excluded by default, but I couldn't find a way to add feature that would exclude ebooklib.