### PR TITLE
OSX pocketsphinx fix

### DIFF
--- a/requirements/python
+++ b/requirements/python
@@ -13,4 +13,4 @@ EbookLib==0.16
 SpeechRecognition==3.7.1
 https://github.com/mattgwwalker/msg-extractor/zipball/master
 six==1.10.0
-pocketsphinx>=0.1.3
+pocketsphinx>=0.1.3,<=0.1.15

--- a/requirements/python
+++ b/requirements/python
@@ -13,4 +13,4 @@ EbookLib==0.16
 SpeechRecognition==3.7.1
 https://github.com/mattgwwalker/msg-extractor/zipball/master
 six==1.10.0
-pocketsphinx==0.1.3
+pocketsphinx>=0.1.3


### PR DESCRIPTION
Fixes the issues around OSX installation due to an outdated version of pocketsphinx being used within requirements. Fix simply changes
```pocketsphinx==0.1.3``` for ```pocketsphinx>=0.1.3,<=0.1.15``` which allows pip to install on both OSX and *nix