### PR TITLE
Editing the command to install cask

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,8 +36,7 @@ OSX
 ---
 
 These steps rely on you having `homebrew <http://brew.sh/>`_ installed
-as well as the `cask <http://caskroom.io/>`_ plugin (``brew install
-caskroom/cask/brew-cask``). The basic idea is to first install
+as well as the `cask <http://caskroom.io/>`_ plugin (``brew tap caskroom/cask``). The basic idea is to first install
 `XQuartz <https://xquartz.macosforge.org/landing/>`_ before
 installing a bunch of system packages before installing textract from
 pypi.


### PR DESCRIPTION
Updating the command on install Cask, [per their website](http://caskroom.io/).

Changing `brew install caskroom/cask/brew-cask` to `brew tap caskroom/cask` in the installation docs for OSX. A small thing that helped me as someone who was new to cask, as the previous command gave me this error:
```bash
==> brew cask install caskroom/cask/brew-cask
Error: Cask 'brew-cask' is unavailable: '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/brew-cask.rb' does not exist.
```