### PR TITLE
bump version of pocketsphinx

### DIFF
--- a/requirements/python
+++ b/requirements/python
@@ -13,4 +13,4 @@ EbookLib==0.16
 SpeechRecognition==3.7.1
 https://github.com/mattgwwalker/msg-extractor/zipball/master
 six==1.10.0
-pocketsphinx==0.1.3
+pocketsphinx==0.1.15


### PR DESCRIPTION
Attempting to install textract fails at building pocketsphinx. Bumping the version to latest makes the following:
```
  ----------------------------------------
  Failed building wheel for pocketsphinx
  Running setup.py clean for pocketsphinx
Failed to build pocketsphinx
Installing collected packages: pocketsphinx, textract, singledispatch, nltk
  Found existing installation: pocketsphinx 0.1.15
    Uninstalling pocketsphinx-0.1.15:
      Successfully uninstalled pocketsphinx-0.1.15
  Running setup.py install for pocketsphinx ... error
    Complete output from command /Users/jonathan.damian/Git/personal/pdf_scan/venv/bin/python3.6 -u -c "import setuptools, tokenize;__file__='/private/var/folders/19/625zqwn90n5bjl8mfhrblbz80000gn/T/pip-install-wlkz0e7h/pocketsphinx/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /private/var/folders/19/625zqwn90n5bjl8mfhrblbz80000gn/T/pip-record-duyn02ns/install-record.txt --single-version-externally-managed --compile --install-headers /Users/jonathan.damian/Git/personal/pdf_scan/venv/bin/../include/site/python3.6/pocketsphinx:
    running install
    running build_ext
    building 'sphinxbase._ad' extension
    swigging swig/sphinxbase/ad.i to swig/sphinxbase/ad_wrap.c
    swig -python -modern -Ideps/sphinxbase/include -Ideps/sphinxbase/include/sphinxbase -I/System/Library/Frameworks/OpenAL.framework/Versions/A/Headers -Ideps/sphinxbase/include/android -Ideps/sphinxbase/swig -outdir sphinxbase -o swig/sphinxbase/ad_wrap.c swig/sphinxbase/ad.i
    unable to execute 'swig': No such file or directory
    error: command 'swig' failed with exit status 1

    ----------------------------------------
```

```
# pip install git+git://github.com/jonathandamian/textract.git@master
Collecting git+git://github.com/jonathandamian/textract.git@master
  Cloning git://github.com/jonathandamian/textract.git (to revision master) to /private/var/folders/19/625zqwn90n5bjl8mfhrblbz80000gn/T/pip-req-build-lvbht41i
Requirement already satisfied: argcomplete==1.8.2 in ./venv/lib/python3.6/site-packages (from textract==1.6.1) (1.8.2)
Requirement already satisfied: chardet==3.0.4 in ./venv/lib/python3.6/site-packages (from textract==1.6.1) (3.0.4)
Requirement already satisfied: python-pptx==0.6.6 in ./venv/lib/python3.6/site-packages (from textract==1.6.1) (0.6.6)
Requirement already satisfied: docx2txt==0.6 in ./venv/lib/python3.6/site-packages (from textract==1.6.1) (0.6)
Requirement already satisfied: beautifulsoup4==4.6.0 in ./venv/lib/python3.6/site-packages (from textract==1.6.1) (4.6.0)
Requirement already satisfied: xlrd==1.0.0 in ./venv/lib/python3.6/site-packages (from textract==1.6.1) (1.0.0)
Requirement already satisfied: EbookLib==0.16 in ./venv/lib/python3.6/site-packages (from textract==1.6.1) (0.16)
Requirement already satisfied: SpeechRecognition==3.7.1 in ./venv/lib/python3.6/site-packages (from textract==1.6.1) (3.7.1)
Requirement already satisfied: six==1.10.0 in ./venv/lib/python3.6/site-packages (from textract==1.6.1) (1.10.0)
Collecting pocketsphinx==0.1.15 (from textract==1.6.1)
  Using cached https://files.pythonhosted.org/packages/54/d5/36eedee7bd8f5ba4297cb6326fe08c5ba0dc42ff3efd0bae4a1e7ea7ffb7/pocketsphinx-0.1.15-cp36-cp36m-macosx_10_13_x86_64.whl
Requirement already satisfied: Pillow>=2.6.1 in ./venv/lib/python3.6/site-packages (from python-pptx==0.6.6->textract==1.6.1) (5.4.1)
Requirement already satisfied: lxml>=3.1.0 in ./venv/lib/python3.6/site-packages (from python-pptx==0.6.6->textract==1.6.1) (4.3.2)
Requirement already satisfied: XlsxWriter>=0.5.7 in ./venv/lib/python3.6/site-packages (from python-pptx==0.6.6->textract==1.6.1) (1.1.5)
Building wheels for collected packages: textract
  Building wheel for textract (setup.py) ... done
  Stored in directory: /private/var/folders/19/625zqwn90n5bjl8mfhrblbz80000gn/T/pip-ephem-wheel-cache-pdpoav4p/wheels/2b/ca/ee/b11472cc557b8b77f5adf6ac3705cfeffbbe472389207a36dd
Successfully built textract
Installing collected packages: pocketsphinx, textract
Successfully installed pocketsphinx-0.1.15 textract-1.6.1
```