### PR TITLE
Update six version requirement to >= 1.10, < 2.0

### DIFF
--- a/requirements/python
+++ b/requirements/python
@@ -12,5 +12,5 @@ xlrd==1.0.0
 EbookLib==0.16
 SpeechRecognition==3.7.1
 https://github.com/mattgwwalker/msg-extractor/zipball/master
-six==1.10.0
+six>=1.10.0,<2.0
 pocketsphinx==0.1.3


### PR DESCRIPTION
Current version of six is 1.12.  Being conservative by keeping less than 2.0.