### PR TITLE
update requirements

### DIFF
--- a/requirements/python
+++ b/requirements/python
@@ -1,16 +1,14 @@
 # This file contains all python dependencies that are required by the textract
 # package in order for it to properly work.
 
-argcomplete==1.8.2
+argcomplete==1.10.0
+beautifulsoup4==4.7.1
 chardet==3.0.4
-python-pptx==0.6.6
-#pdfminer.six <-- go back to this after the shebang fix is released (see https://github.com/goulu/pdfminer/issues/27)
-https://github.com/goulu/pdfminer/zipball/e6ad15af79a26c31f4e384d8427b375c93b03533#egg=pdfminer.six
-docx2txt==0.6
-beautifulsoup4==4.6.0
-xlrd==1.0.0
-EbookLib==0.16
-SpeechRecognition==3.7.1
-https://github.com/mattgwwalker/msg-extractor/zipball/master
-six==1.10.0
-pocketsphinx==0.1.3
+docx2txt==0.8
+EbookLib==0.17.1
+extract-msg==0.23.1
+pdfminer.six==20181108
+python-pptx==0.6.18
+six==1.12.0
+SpeechRecognition==3.8.1
+xlrd==1.2.0

--- a/requirements/python-dev
+++ b/requirements/python-dev
@@ -6,11 +6,11 @@
 -r python-doc
 
 # needed for tests/run.py script to read .travis.yml file
-PyYAML==3.12
-pep8==1.7.0
-coveralls==1.1
-requests==2.18.1
+coveralls==1.8.1
 nose==1.3.7
+pep8==1.7.1
+PyYAML==5.1.1
+requests==2.22.0
 
 # needed for managing versions
 bumpversion==0.5.3

--- a/requirements/python-doc
+++ b/requirements/python-doc
@@ -1,5 +1,5 @@
-# this only includes packages that are needed for documentation build. 
+# this only includes packages that are needed for documentation build.
 
-sphinx==1.6.3
-sphinx_rtd_theme==0.2.4
-sphinx-argparse==0.2.1
+sphinx==2.1.2
+sphinx_rtd_theme==0.4.3
+sphinx-argparse==0.2.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.1
+current_version = 1.6.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import glob
 import os
-import sys
 from setuptools import setup
 
 import textract
@@ -43,7 +42,7 @@ dependencies, dependency_links = parse_requirements(requirements_filename)
 
 setup(
     name=textract.__name__,
-    version="1.6.1",
+    version="1.6.2",
     description="extract text from any document. no muss. no fuss.",
     long_description=long_description,
     url=github_url,
@@ -57,6 +56,9 @@ setup(
         'textract.parsers',
     ],
     install_requires=dependencies,
+    extras_require={
+        "pocketsphinx": ["pocketsphinx==0.1.15"]
+    },
     dependency_links=dependency_links,
     zip_safe=False,
 )


### PR DESCRIPTION
This PR distuingishes 3 different kinds of dependencies

- pure python packages
- python packages with external dependencies*
- external tools

Packages in the first category are updated to their latest version. The second category is made optional. This _only_ affects `pocketsphinx`. The third and last category are dependencies for which `textract` does not provide any means to install. If available, `textract` will use these tools to parse certain file types.

This should fix #284, #280, #274, #267, #262, #243, #194, #193 and #184. As this was a very common issue, the version number of `textract` is bumped to `1.6.2.`

*Some of the packages require `lmxl` which in turn requires the external libraries `libxml2` version 2.9.2 and `libxslt` version 1.1.27 or later. These are often installed by default, and as such packages requering `lxml` are installed by default as well.
