### PR TITLE
Support kwargs for external parsers

### DIFF
--- a/textract/parsers/csv_parser.py
+++ b/textract/parsers/csv_parser.py
@@ -1,6 +1,6 @@
 import csv
 
-from .utils import BaseParser
+from .utils import BaseParser, _call_with_kwargs
 
 
 class Parser(BaseParser):
@@ -13,5 +13,6 @@ class Parser(BaseParser):
 
         # quick 'n dirty solution for the time being
         with open(filename) as stream:
-            reader = csv.reader(stream, delimiter=self.delimiter)
+            kwargs['delimiter'] = self.delimiter
+            reader = _call_with_kwargs(csv.reader, stream, **kwargs)
             return '\n'.join(['\t'.join(row) for row in reader])

--- a/textract/parsers/docx_parser.py
+++ b/textract/parsers/docx_parser.py
@@ -1,6 +1,6 @@
 import docx2txt
 
-from .utils import BaseParser
+from .utils import BaseParser, _call_with_kwargs
 
 
 class Parser(BaseParser):
@@ -8,4 +8,4 @@ class Parser(BaseParser):
     """
 
     def extract(self, filename, **kwargs):
-        return docx2txt.process(filename)
+        return _call_with_kwargs(docx2txt.process, filename, **kwargs)

--- a/textract/parsers/eml_parser.py
+++ b/textract/parsers/eml_parser.py
@@ -1,6 +1,6 @@
 from email.parser import Parser as EmailParser
 
-from .utils import BaseParser
+from .utils import BaseParser, _call_with_kwargs
 
 
 class Parser(BaseParser):
@@ -18,7 +18,7 @@ class Parser(BaseParser):
 
         with open(filename) as stream:
             parser = EmailParser()
-            message = parser.parse(stream)
+            message = _call_with_kwargs(parser.parse, stream, **kwargs)
 
         text_content = []
         for part in message.walk():

--- a/textract/parsers/epub_parser.py
+++ b/textract/parsers/epub_parser.py
@@ -1,7 +1,7 @@
 from ebooklib import epub, ITEM_DOCUMENT
 from bs4 import BeautifulSoup
 
-from .utils import BaseParser
+from .utils import BaseParser, _call_with_kwargs
 
 
 class Parser(BaseParser):
@@ -9,7 +9,7 @@ class Parser(BaseParser):
     """
 
     def extract(self, filename, **kwargs):
-        book = epub.read_epub(filename)
+        book = _call_with_kwargs(epub.read_epub, filename, **kwargs)
         result = ''
         for id, _ in book.spine:
             item = book.get_item_with_id(id)

--- a/textract/parsers/html_parser.py
+++ b/textract/parsers/html_parser.py
@@ -3,7 +3,7 @@ import six
 
 from bs4 import BeautifulSoup
 
-from .utils import BaseParser
+from .utils import BaseParser, _call_with_kwargs
 
 
 class Parser(BaseParser):
@@ -125,8 +125,9 @@ class Parser(BaseParser):
         return soup
 
     def extract(self, filename, **kwargs):
+        kwargs['features'] = 'lxml'
         with open(filename, "rb") as stream:
-            soup = BeautifulSoup(stream, 'lxml')
+            soup = _call_with_kwargs(BeautifulSoup, stream, **kwargs)
 
         # Convert tables to ASCII ones
         soup = self._replace_tables(soup)

--- a/textract/parsers/json_parser.py
+++ b/textract/parsers/json_parser.py
@@ -1,7 +1,7 @@
 import json
 import six
 
-from .utils import BaseParser
+from .utils import BaseParser, _call_with_kwargs
 
 
 class Parser(BaseParser):
@@ -12,7 +12,7 @@ class Parser(BaseParser):
 
     def extract(self, filename, **kwargs):
         with open(filename, 'r') as raw:
-            deserialized_json = json.load(raw)
+            deserialized_json = _call_with_kwargs(json.load, raw, **kwargs)
         return self.get_text(deserialized_json)
 
     def get_text(self, deserialized_json):

--- a/textract/parsers/msg_parser.py
+++ b/textract/parsers/msg_parser.py
@@ -2,7 +2,7 @@ import six
 
 import extract_msg
 
-from .utils import BaseParser
+from .utils import BaseParser, _call_with_kwargs
 
 
 def ensure_bytes(string):
@@ -23,5 +23,5 @@ class Parser(BaseParser):
     """
 
     def extract(self, filename, **kwargs):
-        m = extract_msg.Message(filename)
+        m = _call_with_kwargs(extract_msg.Message, filename, **kwargs)
         return ensure_bytes(m.subject) + six.b('\n\n') + ensure_bytes(m.body)

--- a/textract/parsers/odt_parser.py
+++ b/textract/parsers/odt_parser.py
@@ -1,7 +1,7 @@
 import zipfile
 import xml.etree.ElementTree as ET
 
-from .utils import BaseParser
+from .utils import BaseParser, _call_with_kwargs
 
 
 class Parser(BaseParser):
@@ -12,8 +12,8 @@ class Parser(BaseParser):
         # Inspiration from
         # https://github.com/odoo/odoo/blob/master/addons/document/odt2txt.py
         with open(filename, 'rb') as stream:
-            zip_stream = zipfile.ZipFile(stream)
-            self.content = ET.fromstring(zip_stream.read("content.xml"))
+            zip_stream = _call_with_kwargs(zipfile.ZipFile, stream, **kwargs)
+            self.content = _call_with_kwargs(ET.fromstring, zip_stream.read("content.xml"), **kwargs)
         return self.to_string()
 
     def to_string(self):

--- a/textract/parsers/pptx_parser.py
+++ b/textract/parsers/pptx_parser.py
@@ -1,6 +1,6 @@
 import pptx
 
-from .utils import BaseParser
+from .utils import BaseParser, _call_with_kwargs
 
 
 class Parser(BaseParser):
@@ -8,7 +8,7 @@ class Parser(BaseParser):
     """
 
     def extract(self, filename, **kwargs):
-        presentation = pptx.Presentation(filename)
+        presentation = _call_with_kwargs(pptx.Presentation, filename, **kwargs)
         text_runs = []
         for slide in presentation.slides:
             for shape in slide.shapes:

--- a/textract/parsers/utils.py
+++ b/textract/parsers/utils.py
@@ -6,11 +6,26 @@ import subprocess
 import tempfile
 import os
 import errno
+import inspect
 
 import six
 import chardet
 
 from .. import exceptions
+
+
+def _call_with_kwargs(extraction_function, stream, **kwargs):
+    """
+    Pass arguments from kwargs to calling function
+    :param extraction_function: function to extract text from file. Usually some external library function
+    :param stream: stream or filename
+    :return: result of extraction
+    """
+    func_kwargs = {}
+    for arg in inspect.getfullargspec(extraction_function).args:
+        if arg in kwargs:
+            func_kwargs[arg] = kwargs[arg]
+    return extraction_function(stream, **func_kwargs)
 
 
 class BaseParser(object):
@@ -117,3 +132,4 @@ class ShellParser(BaseParser):
         handle, filename = tempfile.mkstemp()
         os.close(handle)
         return filename
+

--- a/textract/parsers/xlsx_parser.py
+++ b/textract/parsers/xlsx_parser.py
@@ -3,15 +3,14 @@ import six
 
 from six.moves import xrange
 
-from .utils import BaseParser
+from .utils import BaseParser, _call_with_kwargs
 
 
 class Parser(BaseParser):
     """Extract text from Excel files (.xls/xlsx).
     """
-
     def extract(self, filename, **kwargs):
-        workbook = xlrd.open_workbook(filename)
+        workbook = _call_with_kwargs(xlrd.open_workbook, filename, **kwargs)
         sheets_name = workbook.sheet_names()
         output = "\n"
         for names in sheets_name:


### PR DESCRIPTION
Hello!

I used `textract` for parsing xls and xlsx files. And sometimes I need to pass `encoding_override` argument to `xlrd`. At current implementation it's not possible.

I add some code that provides possibility to pass `kwargs` to externals library functions calls. It works with python libraries only (does not support `ShellParser`).

Please check it out!