### PR TITLE
Add installation notes for FreeBSD

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,6 +62,18 @@ pypi.
     homebrew, you may also need to install the python
     development header files for textract to properly install.
 
+FreeBSD
+-------
+
+Setting up this package on FreeBSD pretty much follows the steps for
+Ubuntu / Debian while using ``pkg`` as package manager.
+
+.. code-block:: bash
+
+    pkg install lang/python38 devel/py-pip textproc/libxml2 textproc/libxslt textproc/antiword textproc/unrtf \
+    graphics/poppler print/pstotext graphics/tesseract audio/flac multimedia/ffmpeg audio/lame audio/sox \
+    graphics/jpeg-turbo
+    pip install textract
 
 Don't see your operating system installation instructions here?
 ---------------------------------------------------------------

--- a/requirements/freebsd
+++ b/requirements/freebsd
@@ -1,0 +1,36 @@
+# required packages
+audio/pulseaudio
+devel/git
+
+# these packages are required by python-docx, which depends on lxml
+# and requires these things
+lang/python38
+devel/py-pippython-pip
+textproc/libxml2
+textproc/libxslt
+
+# parse word documents
+textproc/antiword
+
+# parse rtf documents
+textproc/unrtf
+
+# parse image files
+graphics/tesseract
+graphics/jpeg-turbo
+
+# parse pdfs
+graphics/poppler
+
+# parse postscript files
+print/pstotext
+
+# parse audio files, with SpeechRecognition
+audio/flac 
+
+# filetype conversion libs
+multimedia/ffmpeg
+audio/lame
+
+# convert audio files
+audio/sox


### PR DESCRIPTION
Adds some remarks on how to install textract on FreeBSD, including the respective requirements file.