### PR TITLE
Update MacOS cask instruction

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -43,7 +43,7 @@ pypi.
 
 .. code-block:: bash
 
-    brew cask install xquartz
+    brew install --cask xquartz
     brew install poppler antiword unrtf tesseract swig
     pip install textract
 


### PR DESCRIPTION
As of 2021, `brew cask install xquartz`  gives `Error: Unknown command: cask`. You have to change it to `brew install --cask xquartz`