### PR TITLE
Fix issue deanmalmgren#342

### DIFF
--- a/textract/parsers/msg_parser.py
+++ b/textract/parsers/msg_parser.py
@@ -8,13 +8,15 @@ from .utils import BaseParser
 def ensure_bytes(string):
     """Normalize string to bytes.
 
-    `ExtractMsg.Message._getStringStream` can return unicode or bytes depending
+    `extract_msg.Message._getStringStream` can return unicode or bytes depending
     on what is originally stored in message file.
 
     This helper functon makes sure, that bytes type is returned.
     """
     if isinstance(string, six.string_types):
         return string.encode('utf-8')
+    if string is None:
+        return b''
     return string
 
 


### PR DESCRIPTION
Added a fix for issue #342 caused by `extract_msg.Message._getStringStream` returning `None` for streams that are not found in the MSG file (this is intentional and should be handled accordingly). `ensure_bytes` now checks for `None` and returns an empty bytes string when found.

Additionally, updated the naming used in the documentation to match the current naming.

Also, for clarification, `extract_msg.Message._getStringStream` should only *ever* be returning `unicode` on Python 2 and `str` on Python 3. If this is not the case, that is a bug that should be reported.

(By the way, contributing guidelines say to use issue2pr for existing issues, but I couldn't get it to work at all.)