### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -80,10 +80,10 @@ Don't see your operating system installation instructions here?
 
 My apologies! Installing system packages is a bit of a drag and its
 hard to anticipate all of the different environments that need to be
-accomodated (wouldn't it be awesome if there were a system-agnostic
+accommodated (wouldn't it be awesome if there were a system-agnostic
 package manager or, better yet, if python could install these system
 dependencies for you?!?!). If you're operating system doesn't have
-documenation about how to install the textract dependencies, please
+documentation about how to install the textract dependencies, please
 :ref:`contribute a pull request <contributing>` with:
 
 1. A new section in here with the appropriate details about how to

--- a/textract/exceptions.py
+++ b/textract/exceptions.py
@@ -3,7 +3,7 @@ import os
 
 # traceback from exceptions that inherit from this class are suppressed
 class CommandLineError(Exception):
-    """The traceback of all CommandLineError's is supressed when the
+    """The traceback of all CommandLineError's is suppressed when the
     errors occur on the command line to provide a useful command line
     interface.
     """


### PR DESCRIPTION
There are small typos in:
- docs/installation.rst
- textract/exceptions.py

Fixes:
- Should read `suppressed` rather than `supressed`.
- Should read `documentation` rather than `documenation`.
- Should read `accommodated` rather than `accomodated`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md