### PR TITLE
Enable encoding detection for the txt parser

### DIFF
--- a/textract/parsers/txt_parser.py
+++ b/textract/parsers/txt_parser.py
@@ -5,5 +5,5 @@ class Parser(BaseParser):
     """Parse ``.txt`` files"""
 
     def extract(self, filename, **kwargs):
-        with open(filename) as stream:
+        with open(filename, "rb") as stream:
             return stream.read()


### PR DESCRIPTION
As of now, the txt parser reads files in text mode as UTF-8 and fails with other encodings. This makes it return a bytes object, leaving the base `decode` to figure out the encoding and act accordingly.