### PR TITLE
Fix Parser to ignore encoding errors

### DIFF
--- a/textract/parsers/txt_parser.py
+++ b/textract/parsers/txt_parser.py
@@ -5,5 +5,5 @@ class Parser(BaseParser):
     """Parse ``.txt`` files"""
 
     def extract(self, filename, **kwargs):
-        with open(filename) as stream:
+        with open(filename, errors='ignore') as stream:
             return stream.read()


### PR DESCRIPTION
This PR could fix errors like "codec can't decode byte XXX in position YYY" that now happens quite often and cannot be solved by any API parameters rather than fixing textract's sources directly.