### PR TITLE
treat ShellError when call pdf2txt.py

### DIFF
--- a/textract/parsers/pdf_parser.py
+++ b/textract/parsers/pdf_parser.py
@@ -52,7 +52,7 @@ class Parser(ShellParser):
         pdf2txt_path = find_executable('pdf2txt.py')
         try:
             stdout, _ = self.run(['pdf2txt.py', filename])
-        except OSError:
+        except (OSError, ShellError):
             try:
                 stdout, _ = self.run(['python3',pdf2txt_path, filename])
             except ShellError:


### PR DESCRIPTION
Environment:
- machine : MacBook Pro, M1 Max chip, 
- OS : Ventura 13.4(22F66)
- python version : 3.10.6
- dependency
	textract (1.6.5)
	argcomplete (1.10.3)
	beautifulsoup4 (4.8.2)
	chardet (3.0.4)
	docx2txt (0.8)
	extract-msg (0.28.7)
	pdfminer.six (20191110)
	python-pptx (0.6.23)
	six (1.12.0)
	SpeechRecognition (3.8.1)
	xlrd (1.2.0)
	pycryptodome (3.19.1)
	sortedcontainers  (2.4.0)
	soupsieve (2.5)
	imapclient (2.1.0)
	olefile (0.47)
	tzlocal (5.2)
	compressed-rtf (1.0.6)
	ebcdic (1.1.1)
	lxml (5.0.0)
	Pillow (10.0.0)
	XlsxWriter (3.1.9)


When execute next code,
```python
textract.process("test.pdf", method='pdfminer')
``` 

it failed with error message

```shell
b"/Users/rim/.pyenv/versions/3.10.6/bin/pdf2txt.py: 
line 1: A command line tool for extracting text and images from PDF and output it to plain text, html, xml or tags.: command not found\n/Users/rim/.pyenv/versions/3.10.6/bin/pdf2txt.py: 
line 2: import: command not found\n/Users/rim/.pyenv/versions/3.10.6/bin/pdf2txt.py: 
line 3: import: command not found\n/Users/rim/.pyenv/versions/3.10.6/bin/pdf2txt.py: 
line 4: import: command not found\n/Users/rim/.pyenv/versions/3.10.6/bin/pdf2txt.py: 
line 5: import: command not found\n/Users/rim/.pyenv/versions/3.10.6/bin/pdf2txt.py: 
line 7: import: command not found\n/Users/rim/.pyenv/versions/3.10.6/bin/pdf2txt.py: 
line 8: import: command not found\n/Users/rim/.pyenv/versions/3.10.6/bin/pdf2txt.py: 
line 9: from: command not found\n/Users/rim/.pyenv/versions/3.10.6/bin/pdf2txt.py: 
line 14: syntax error near unexpected token `def'\n/Users/rim/.pyenv/versions/3.10.6/bin/pdf2txt.py: 
line 14: `def extract_text(files=[], outfile='-','\n"
``` 

self.run(...) of following code in textract/parsers/pdf_parser.py throws not OSError but ShellError, so SheelError is not treated . Just ShellError added in catch block.

```python
class Parser(ShellParser):

	def extract_pdfminer(self, filename, **kwargs):
        	...

		try:
			stdout, _ = self.run(['pdf2txt.py', filename])
	        except OSError:
			...
``` 