### PR TITLE
Fixed bug

### DIFF
--- a/requirements/python
+++ b/requirements/python
@@ -5,7 +5,7 @@ argcomplete~=1.10.0
 beautifulsoup4~=4.8.0
 chardet==3.*
 docx2txt~=0.8
-extract-msg<=0.29.* #Last with python2 support
+extract-msg<=0.29.6 #Last with python2 support
 pdfminer.six==20191110 #Last with python2 support
 python-pptx~=0.6.18
 six~=1.12.0


### PR DESCRIPTION
 has invalid metadata: .* suffix can only be used with `==` or `!=` operators
    extract-msg (<=0.29.*)
                 ~~~~~~~^

0.29.6 is the last release on their releases page.