### PR TITLE
feat(#51): replace deprecated antiword with LibreOffice

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,13 +6,6 @@ inputs:
   python-version:
     description: Python version
     required: true
-  install-libreoffice:
-    description: >-
-      Install LibreOffice so the legacy .doc tests run. When "false" the .doc
-      tests skip automatically (soffice is absent). Kept off for PRs that don't
-      touch .doc-related files to avoid the heavy install.
-    required: false
-    default: "true"
 
 runs:
   using: composite
@@ -48,7 +41,7 @@ runs:
         Add-Content -Path $env:GITHUB_PATH -Value $popplerBin
 
     - name: Install LibreOffice for .doc tests (Ubuntu)
-      if: runner.os == 'Linux' && inputs.install-libreoffice == 'true'
+      if: runner.os == 'Linux'
       uses: awalsh128/cache-apt-pkgs-action@v1
       with:
         # Full meta-package avoids a headless UNO crash seen with libreoffice-writer alone.
@@ -56,12 +49,12 @@ runs:
         version: 1.1
 
     - name: Install LibreOffice for .doc tests (macOS)
-      if: runner.os == 'macOS' && inputs.install-libreoffice == 'true'
+      if: runner.os == 'macOS'
       shell: bash
       run: brew install --cask libreoffice
 
     - name: Install LibreOffice for .doc tests (Windows)
-      if: runner.os == 'Windows' && inputs.install-libreoffice == 'true'
+      if: runner.os == 'Windows'
       shell: pwsh
       run: |
         choco install libreoffice-fresh -y

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -51,7 +51,8 @@ runs:
       if: runner.os == 'Linux' && inputs.install-libreoffice == 'true'
       uses: awalsh128/cache-apt-pkgs-action@v1
       with:
-        packages: libreoffice-writer
+        # Full meta-package avoids a headless UNO crash seen with libreoffice-writer alone.
+        packages: libreoffice dbus-x11
         version: 1.1
 
     - name: Install LibreOffice for .doc tests (macOS)

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,7 +14,8 @@ runs:
       if: runner.os == 'Linux'
       uses: awalsh128/cache-apt-pkgs-action@v1
       with:
-        packages: tesseract-ocr sox libsox-fmt-mp3 ghostscript unrtf poppler-utils
+        # Full libreoffice meta-package avoids a headless UNO crash seen with libreoffice-writer alone.
+        packages: tesseract-ocr sox libsox-fmt-mp3 ghostscript unrtf poppler-utils libreoffice dbus-x11
         version: 1.1
 
     - name: Install system dependencies (macOS)
@@ -22,12 +23,13 @@ runs:
       shell: bash
       run: |
         brew install tesseract sox lame mad ghostscript unrtf poppler
+        brew install --cask libreoffice
 
     - name: Install system dependencies (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        choco install make tesseract ghostscript sox.portable poppler -y
+        choco install make tesseract ghostscript sox.portable poppler libreoffice-fresh -y
         # Add tesseract installation directory to PATH
         Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files\Tesseract-OCR"
         # For ghostscript, the version number is in the path, so find it dynamically
@@ -39,25 +41,6 @@ runs:
         $popplerBin = Get-ChildItem "C:\tools" -Recurse -Filter "pdftoppm.exe" -ErrorAction SilentlyContinue |
             Select-Object -First 1 -ExpandProperty DirectoryName
         Add-Content -Path $env:GITHUB_PATH -Value $popplerBin
-
-    - name: Install LibreOffice for .doc tests (Ubuntu)
-      if: runner.os == 'Linux'
-      uses: awalsh128/cache-apt-pkgs-action@v1
-      with:
-        # Full meta-package avoids a headless UNO crash seen with libreoffice-writer alone.
-        packages: libreoffice dbus-x11
-        version: 1.1
-
-    - name: Install LibreOffice for .doc tests (macOS)
-      if: runner.os == 'macOS'
-      shell: bash
-      run: brew install --cask libreoffice
-
-    - name: Install LibreOffice for .doc tests (Windows)
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        choco install libreoffice-fresh -y
         # Add LibreOffice (soffice.exe) to PATH for the .doc parser
         Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files\LibreOffice\program"
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,6 +6,13 @@ inputs:
   python-version:
     description: Python version
     required: true
+  install-libreoffice:
+    description: >-
+      Install LibreOffice so the legacy .doc tests run. When "false" the .doc
+      tests skip automatically (soffice is absent). Kept off for PRs that don't
+      touch .doc-related files to avoid the heavy install.
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -14,14 +21,14 @@ runs:
       if: runner.os == 'Linux'
       uses: awalsh128/cache-apt-pkgs-action@v1
       with:
-        packages: antiword tesseract-ocr sox libsox-fmt-mp3 ghostscript unrtf poppler-utils
+        packages: tesseract-ocr sox libsox-fmt-mp3 ghostscript unrtf poppler-utils
         version: 1.1
 
     - name: Install system dependencies (macOS)
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew install antiword tesseract sox lame mad ghostscript unrtf poppler
+        brew install tesseract sox lame mad ghostscript unrtf poppler
 
     - name: Install system dependencies (Windows)
       if: runner.os == 'Windows'
@@ -39,6 +46,26 @@ runs:
         $popplerBin = Get-ChildItem "C:\tools" -Recurse -Filter "pdftoppm.exe" -ErrorAction SilentlyContinue |
             Select-Object -First 1 -ExpandProperty DirectoryName
         Add-Content -Path $env:GITHUB_PATH -Value $popplerBin
+
+    - name: Install LibreOffice for .doc tests (Ubuntu)
+      if: runner.os == 'Linux' && inputs.install-libreoffice == 'true'
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: libreoffice-writer
+        version: 1.1
+
+    - name: Install LibreOffice for .doc tests (macOS)
+      if: runner.os == 'macOS' && inputs.install-libreoffice == 'true'
+      shell: bash
+      run: brew install --cask libreoffice
+
+    - name: Install LibreOffice for .doc tests (Windows)
+      if: runner.os == 'Windows' && inputs.install-libreoffice == 'true'
+      shell: pwsh
+      run: |
+        choco install libreoffice-fresh -y
+        # Add LibreOffice (soffice.exe) to PATH for the .doc parser
+        Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files\LibreOffice\program"
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -38,50 +38,18 @@ jobs:
             fi
           fi
 
-  changes:
-    name: Detect Changes
-    runs-on: ubuntu-latest
-    outputs:
-      # Whether to install LibreOffice (and thus run the legacy .doc tests).
-      libreoffice: ${{ steps.detect.outputs.libreoffice }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Detect .doc-related changes
-        id: detect
-        shell: bash
-        run: |
-          # Always install on push (main / tags); on PRs only when the change
-          # touches .doc parsing, its tests, or the CI setup itself.
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "libreoffice=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          BASE=${{ github.event.pull_request.base.sha }}
-          HEAD=${{ github.event.pull_request.head.sha }}
-          if git diff --name-only "$BASE" "$HEAD" | grep -qE '^(textract/parsers/doc_parser\.py|textract/exceptions\.py|tests/test_doc\.py|tests/doc/|\.github/actions/setup/action\.yml|\.github/workflows/ci_pipeline\.yml)'; then
-            echo "libreoffice=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "libreoffice=false" >> "$GITHUB_OUTPUT"
-          fi
-
   test:
-    needs: changes
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        # On PRs, test all OSes on a single Python for fast feedback. On push
-        # to main and tags, test the full Python range before release.
-        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.14"]') || fromJSON('["3.9", "3.14"]') }}
+        python-version: ["3.9", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
         with:
           python-version: ${{ matrix.python-version }}
-          install-libreoffice: ${{ needs.changes.outputs.libreoffice }}
 
       - name: Run tests
         id: tests

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -8,10 +8,15 @@ name: CI Pipeline
   pull_request:
     paths:
       - .github/workflows/ci_pipeline.yml
+      - .github/actions/setup/action.yml
       - textract/**
       - tests/**
       - uv.lock
       - pyproject.toml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   changelog-check:
@@ -33,18 +38,50 @@ jobs:
             fi
           fi
 
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      # Whether to install LibreOffice (and thus run the legacy .doc tests).
+      libreoffice: ${{ steps.detect.outputs.libreoffice }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Detect .doc-related changes
+        id: detect
+        shell: bash
+        run: |
+          # Always install on push (main / tags); on PRs only when the change
+          # touches .doc parsing, its tests, or the CI setup itself.
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "libreoffice=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE '^(textract/parsers/doc_parser\.py|textract/exceptions\.py|tests/test_doc\.py|tests/doc/|\.github/actions/setup/action\.yml|\.github/workflows/ci_pipeline\.yml)'; then
+            echo "libreoffice=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "libreoffice=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test:
+    needs: changes
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.14"]
+        # On PRs, test all OSes on a single Python for fast feedback. On push
+        # to main and tags, test the full Python range before release.
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.14"]') || fromJSON('["3.9", "3.14"]') }}
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
         with:
           python-version: ${{ matrix.python-version }}
+          install-libreoffice: ${{ needs.changes.outputs.libreoffice }}
 
       - name: Run tests
         id: tests

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ TBD
 * Minor nitpick to remove unused line (`#562`_ by `@KyleKing`_)
 * Utilize openpyxl for xlsx after xlrd dropped support (`#544`_ by `@KyleKing`_)
 * Prevent opening a cmd window with ``Popen()`` on Windows (`#574`_ by `@KyleKing`_)
+* Replace unmaintained ``antiword`` with LibreOffice for ``.doc`` extraction (`#582`_ by `@KyleKing`_)
 
 2.0.0
 -------------------
@@ -400,3 +401,4 @@ TBD
 .. _#559: https://github.com/deanmalmgren/textract/pull/559
 .. _#562: https://github.com/deanmalmgren/textract/pull/562
 .. _#574: https://github.com/deanmalmgren/textract/pull/574
+.. _#582: https://github.com/deanmalmgren/textract/pull/582

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -201,15 +201,15 @@ for upstream context.
 
 Install system dependencies (macOS, using `Homebrew <https://brew.sh/>`_)::
 
-    brew install antiword tesseract ghostscript poppler sox unrtf
+    brew install libreoffice tesseract ghostscript poppler sox unrtf
 
 Install system dependencies (Ubuntu/Debian)::
 
-    apt-get install antiword tesseract-ocr ghostscript poppler-utils sox libsox-fmt-mp3 unrtf
+    apt-get install libreoffice-writer tesseract-ocr ghostscript poppler-utils sox libsox-fmt-mp3 unrtf
 
 Install system dependencies (Windows, using `Chocolatey <https://chocolatey.org/install>`_)::
 
-    choco install tesseract ghostscript sox.portable poppler -y
+    choco install tesseract ghostscript sox.portable poppler libreoffice-fresh -y
 
 .. note::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,7 +46,7 @@ file types by either mentioning them on the `issue tracker
 
 * ``.tsv`` and ``.tab`` via python builtins
 
-* ``.doc`` via `antiword`_
+* ``.doc`` via `LibreOffice`_ (optional; see installation docs)
 
 * ``.docx`` via `python-docx2txt`_
 
@@ -91,7 +91,7 @@ file types by either mentioning them on the `issue tracker
 * ``.xls`` via `xlrd <https://pypi.python.org/pypi/xlrd>`_
 
 .. this is a list of all the packages that textract uses for extraction
-.. _antiword: http://www.winfield.demon.nl/
+.. _LibreOffice: https://www.libreoffice.org/
 .. _beautifulsoup4: http://beautiful-soup-4.readthedocs.org/en/latest/
 .. _ebooklib: https://github.com/aerkalov/ebooklib
 .. _msg-extractor: https://github.com/mattgwwalker/msg-extractor

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,6 +35,11 @@ First install system packages using apt-get, then install textract from PyPI:
 
 .. note::
 
+    ``libreoffice-writer`` is *optional*: it is only needed to extract legacy
+    ``.doc`` (Word 97-2003) files. See :ref:`converting-legacy-doc-files`.
+
+.. note::
+
     It may also be necessary to install ``zlib1g-dev`` on Docker
     instances of Ubuntu. See `issue #19
     <https://github.com/deanmalmgren/textract/pull/19>`_ for details
@@ -52,6 +57,11 @@ First install XQuartz and system packages, then install textract from PyPI:
     pip install textract
     # or with uv
     uv pip install textract
+
+.. note::
+
+    ``libreoffice`` is *optional*: it is only needed to extract legacy
+    ``.doc`` (Word 97-2003) files. See :ref:`converting-legacy-doc-files`.
 
 .. note::
 
@@ -102,6 +112,11 @@ Install `Chocolatey <https://chocolatey.org/install>`_ then install system packa
 
 .. note::
 
+    ``libreoffice-fresh`` is *optional*: it is only needed to extract legacy
+    ``.doc`` (Word 97-2003) files. See :ref:`converting-legacy-doc-files`.
+
+.. note::
+
     Two parsers are **not supported on Windows**:
 
     - ``.mp3`` / ``.ogg``: `sox.portable <https://community.chocolatey.org/packages/sox.portable>`_
@@ -127,6 +142,11 @@ First install system packages using pkg, then install textract from PyPI:
     pip install textract
     # or with uv
     uv pip install textract
+
+.. note::
+
+    ``editors/libreoffice`` is *optional*: it is only needed to extract
+    legacy ``.doc`` (Word 97-2003) files. See :ref:`converting-legacy-doc-files`.
 
 .. _converting-legacy-doc-files:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,7 +27,7 @@ First install system packages using apt-get, then install textract from PyPI:
 
 .. code-block:: bash
 
-    apt-get install python-dev libxml2-dev libxslt1-dev antiword unrtf poppler-utils ghostscript tesseract-ocr \
+    apt-get install python-dev libxml2-dev libxslt1-dev libreoffice-writer unrtf poppler-utils ghostscript tesseract-ocr \
     flac ffmpeg lame libmad0 libsox-fmt-mp3 sox libjpeg-dev swig libpulse-dev
     pip install textract
     # or with uv
@@ -47,8 +47,8 @@ First install XQuartz and system packages, then install textract from PyPI:
 
 .. code-block:: bash
 
-    brew install --cask xquartz
-    brew install antiword ghostscript poppler sox tesseract unrtf swig
+    brew install --cask xquartz libreoffice
+    brew install ghostscript poppler sox tesseract unrtf swig
     pip install textract
     # or with uv
     uv pip install textract
@@ -95,7 +95,7 @@ Install `Chocolatey <https://chocolatey.org/install>`_ then install system packa
 
 .. code-block:: powershell
 
-    choco install tesseract ghostscript sox.portable poppler -y
+    choco install tesseract ghostscript sox.portable poppler libreoffice-fresh -y
     pip install textract
     # or with uv
     uv pip install textract
@@ -121,12 +121,35 @@ First install system packages using pkg, then install textract from PyPI:
 
 .. code-block:: bash
 
-    pkg install lang/python38 devel/py-pip textproc/libxml2 textproc/libxslt textproc/antiword textproc/unrtf \
+    pkg install lang/python38 devel/py-pip textproc/libxml2 textproc/libxslt editors/libreoffice textproc/unrtf \
     graphics/poppler print/pstotext graphics/tesseract audio/flac multimedia/ffmpeg audio/lame audio/sox \
     graphics/jpeg-turbo
     pip install textract
     # or with uv
     uv pip install textract
+
+.. _converting-legacy-doc-files:
+
+Converting legacy ``.doc`` files
+--------------------------------
+
+Legacy ``.doc`` (Word 97-2003 binary) files are extracted with LibreOffice,
+which is an *optional* runtime dependency: textract only shells out to the
+``soffice`` executable when you actually process a ``.doc`` file, and every
+other format works without it.
+
+If you would rather not install LibreOffice alongside textract (for example in
+a slim container), you can pre-convert your ``.doc`` files to ``.docx`` once,
+elsewhere, and hand the results to textract, whose ``.docx`` parser is pure
+Python:
+
+.. code-block:: bash
+
+    soffice --headless --convert-to docx --outdir out/ *.doc
+
+Then run ``textract out/whatever.docx`` as usual. This keeps the heavier
+converter out of your extraction pipeline while still supporting legacy
+documents.
 
 Reference: CI System Dependencies
 ----------------------------------
@@ -164,8 +187,13 @@ documentation about how to install the textract dependencies, please
 
     - python header files are required for building lxml.
 
-    - `antiword <https://github.com/grobian/antiword>`_ is required by the
-      ``.doc`` parser (note: no longer actively maintained).
+    - `LibreOffice <https://www.libreoffice.org/>`_ (the ``soffice``
+      executable) is *optionally* required by the ``.doc`` parser. It is only
+      invoked when you extract a legacy ``.doc`` file; if it isn't installed,
+      textract raises an error explaining how to install it or pre-convert the
+      file. This replaces ``antiword``, which is no longer maintained or
+      packaged. See :ref:`converting-legacy-doc-files` for a batch
+      pre-conversion alternative.
 
     - `pdftotext <https://poppler.freedesktop.org/>`_ (part of poppler) is
       *optionally* required by the ``.pdf`` parser (there is a pure python

--- a/tests/doc/raw_text.txt
+++ b/tests/doc/raw_text.txt
@@ -1,51 +1,11 @@
-
-I love word documents. They are lovely. They make me so happy I could
-smile. And that is why I wrote this package.
+I love word documents. They are lovely. They make me so happy I could smile. And that is why I wrote this package.
 
 Sample text is hard. That is where http://hipsum.co comes in handy.
 
-Semiotics church-key VHS, Truffaut cliche actually vegan. Cray Austin pop-
-up disrupt letterpress, kitsch fixie Cosby sweater cliche craft beer PBR&B.
-Gentrify cornhole Tonx McSweeney's, Shoreditch keffiyeh ethnic Marfa 90's
-kogi American Apparel. Shabby chic distillery church-key locavore beard,
-food truck chillwave sartorial deep v flannel authentic Tumblr narwhal kogi
-organic. Cred vegan jean shorts Banksy forage Neutra dreamcatcher, hashtag
-Bushwick polaroid pork belly flannel keytar Portland post-ironic. Cred
-hoodie vegan, food truck leggings Austin pour-over banjo trust fund before
-they sold out cray Intelligentsia plaid typewriter. Williamsburg XOXO plaid
-Carles Austin tofu.
-
-Carles Tonx keffiyeh, leggings 90's lo-fi kogi viral semiotics Brooklyn
-biodiesel tousled bespoke kitsch. Vinyl Tonx art party Thundercats retro,
-viral asymmetrical artisan bicycle rights bitters master cleanse
-Kickstarter YOLO. Seitan street art semiotics twee skateboard, PBR&B VHS
-hashtag meh. Thundercats semiotics shabby chic forage single-origin coffee
-retro, 3 wolf moon iPhone mumblecore 90's trust fund Intelligentsia. Beard
-gluten-free seitan, VHS sartorial pork belly gastropub meh whatever
-authentic synth. Beard single-origin coffee irony fixie, before they sold
-out Pitchfork kitsch readymade. Helvetica butcher wayfarers, lomo artisan
-hashtag Brooklyn four loko fanny pack 90's mustache 8-bit.
-
-Meh jean shorts selfies, crucifix selvage Helvetica Carles PBR Vice Banksy
-roof party master cleanse ugh PBR&B. Lo-fi freegan salvia photo booth, Wes
-Anderson skateboard Odd Future. Etsy art party Bushwick keffiyeh. Pork
-belly 3 wolf moon butcher mustache. YOLO raw denim lo-fi, hoodie gentrify
-Schlitz 8-bit sriracha Shoreditch retro brunch. Williamsburg farm-to-table
-beard, mlkshk Banksy fap kogi Etsy art party squid semiotics. XOXO church-
-key Pitchfork mlkshk irony tote bag.
-
-Farm-to-table brunch tattooed hoodie keytar, literally selvage authentic
-trust fund deep v Thundercats Kickstarter narwhal locavore. Swag disrupt
-chambray, leggings shabby chic gastropub YOLO plaid hoodie Williamsburg
-Godard mixtape. Retro Godard keytar biodiesel, freegan paleo Etsy you
-probably haven't heard of them Pitchfork Schlitz readymade small batch
-cred. Pug trust fund paleo, 90's fixie typewriter next level banjo. Banksy
-occupy authentic master cleanse Bushwick fingerstache selfies, direct trade
-craft beer cliche +1 cray. Locavore four loko biodiesel Neutra chia mlkshk.
-Fanny pack YOLO Portland, mlkshk PBR&B single-origin coffee drinking
-vinegar 8-bit flannel gentrify stumptown pop-up.
+Semiotics church-key VHS, Truffaut cliche actually vegan. Cray Austin pop-up disrupt letterpress, kitsch fixie Cosby sweater cliche craft beer PBR&B. Gentrify cornhole Tonx McSweeney's, Shoreditch keffiyeh ethnic Marfa 90's kogi American Apparel. Shabby chic distillery church-key locavore beard, food truck chillwave sartorial deep v flannel authentic Tumblr narwhal kogi organic. Cred vegan jean shorts Banksy forage Neutra dreamcatcher, hashtag Bushwick polaroid pork belly flannel keytar Portland post-ironic. Cred hoodie vegan, food truck leggings Austin pour-over banjo trust fund before they sold out cray Intelligentsia plaid typewriter. Williamsburg XOXO plaid Carles Austin tofu.
+Carles Tonx keffiyeh, leggings 90's lo-fi kogi viral semiotics Brooklyn biodiesel tousled bespoke kitsch. Vinyl Tonx art party Thundercats retro, viral asymmetrical artisan bicycle rights bitters master cleanse Kickstarter YOLO. Seitan street art semiotics twee skateboard, PBR&B VHS hashtag meh. Thundercats semiotics shabby chic forage single-origin coffee retro, 3 wolf moon iPhone mumblecore 90's trust fund Intelligentsia. Beard gluten-free seitan, VHS sartorial pork belly gastropub meh whatever authentic synth. Beard single-origin coffee irony fixie, before they sold out Pitchfork kitsch readymade. Helvetica butcher wayfarers, lomo artisan hashtag Brooklyn four loko fanny pack 90's mustache 8-bit.
+Meh jean shorts selfies, crucifix selvage Helvetica Carles PBR Vice Banksy roof party master cleanse ugh PBR&B. Lo-fi freegan salvia photo booth, Wes Anderson skateboard Odd Future. Etsy art party Bushwick keffiyeh. Pork belly 3 wolf moon butcher mustache. YOLO raw denim lo-fi, hoodie gentrify Schlitz 8-bit sriracha Shoreditch retro brunch. Williamsburg farm-to-table beard, mlkshk Banksy fap kogi Etsy art party squid semiotics. XOXO church-key Pitchfork mlkshk irony tote bag.
+Farm-to-table brunch tattooed hoodie keytar, literally selvage authentic trust fund deep v Thundercats Kickstarter narwhal locavore. Swag disrupt chambray, leggings shabby chic gastropub YOLO plaid hoodie Williamsburg Godard mixtape. Retro Godard keytar biodiesel, freegan paleo Etsy you probably haven't heard of them Pitchfork Schlitz readymade small batch cred. Pug trust fund paleo, 90's fixie typewriter next level banjo. Banksy occupy authentic master cleanse Bushwick fingerstache selfies, direct trade craft beer cliche +1 cray. Locavore four loko biodiesel Neutra chia mlkshk. Fanny pack YOLO Portland, mlkshk PBR&B single-origin coffee drinking vinegar 8-bit flannel gentrify stumptown pop-up.
 Oh. You need a little dummy text for your mockup? How quaint.
-
 I bet you are still using Bootstrap too
-
 

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -1,18 +1,19 @@
 """Tests for DOC file format."""
 
-import shutil
 import unittest
 
 import pytest
 
+from textract.parsers.doc_parser import _find_soffice
+
 from . import base
 
-_HAS_ANTIWORD = shutil.which("antiword") is not None
+_HAS_SOFFICE = _find_soffice() is not None
 
 
 @pytest.mark.skipif(
-    not _HAS_ANTIWORD,
-    reason=("antiword is not installed (install via your system package manager)"),
+    not _HAS_SOFFICE,
+    reason="LibreOffice (soffice) is not installed",
 )
 class DocTestCase(base.ShellParserTestCase, unittest.TestCase):
     """Test text extraction from DOC files."""

--- a/textract/exceptions.py
+++ b/textract/exceptions.py
@@ -78,6 +78,21 @@ class UnknownMethod(CommandLineError):
         )
 
 
+class LibreOfficeNotFound(CommandLineError):
+    """Raised when a ``.doc`` file needs LibreOffice but it can't be found."""
+
+    def __str__(self):
+        return self.render(
+            "Extracting text from legacy .doc files requires LibreOffice\n"
+            "(the `soffice` executable), which could not be found on your\n"
+            "system or PATH. Either install it:\n\n"
+            "    http://textract.readthedocs.org/en/latest/installation.html\n\n"
+            "or convert the file to .docx (or .pdf) first and pass that to\n"
+            "textract instead. To batch-convert with LibreOffice:\n\n"
+            "    soffice --headless --convert-to docx --outdir out/ *.doc\n"
+        )
+
+
 class ShellError(CommandLineError):
     """This error is raised when a shell.run returns a non-zero exit code
     (meaning the command failed).

--- a/textract/parsers/doc_parser.py
+++ b/textract/parsers/doc_parser.py
@@ -1,9 +1,65 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from tempfile import mkdtemp
+
+from textract.exceptions import LibreOfficeNotFound, ShellError
+
 from .utils import ShellParser
+
+_SOFFICE_CANDIDATES = (
+    "soffice",
+    "libreoffice",
+    "/Applications/LibreOffice.app/Contents/MacOS/soffice",
+    "/opt/libreoffice/program/soffice",
+    r"C:\Program Files\LibreOffice\program\soffice.exe",
+    r"C:\Program Files (x86)\LibreOffice\program\soffice.exe",
+)
+
+
+def _find_soffice() -> str | None:
+    for candidate in _SOFFICE_CANDIDATES:
+        if resolved := shutil.which(candidate):
+            return resolved
+        if Path(candidate).is_file():
+            return candidate
+    return None
 
 
 class Parser(ShellParser):
-    """Extract text from doc files using antiword."""
+    """Extract text from legacy .doc files using LibreOffice.
+
+    LibreOffice is an optional runtime dependency: if the ``soffice``
+    executable can't be found, a :class:`.LibreOfficeNotFound` error is
+    raised explaining how to install it or pre-convert the file.
+    """
 
     def extract(self, filename, **kwargs):
-        stdout, stderr = self.run(["antiword", filename])
-        return stdout
+        soffice = _find_soffice()
+        if soffice is None:
+            raise LibreOfficeNotFound()
+
+        temp_dir = mkdtemp()
+        try:
+            profile_uri = (Path(temp_dir) / "profile").as_uri()
+            stdout, stderr = self.run(
+                [
+                    soffice,
+                    "--headless",
+                    f"-env:UserInstallation={profile_uri}",
+                    "--convert-to",
+                    "txt:Text (encoded):UTF8",
+                    "--outdir",
+                    temp_dir,
+                    filename,
+                ]
+            )
+            output = Path(temp_dir) / f"{Path(filename).stem}.txt"
+            if not output.is_file():
+                raise ShellError(
+                    f"soffice --convert-to txt {filename}", 1, stdout, stderr
+                )
+            return output.read_text(encoding="utf-8-sig")
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)

--- a/textract/parsers/utils.py
+++ b/textract/parsers/utils.py
@@ -85,7 +85,7 @@ class ShellParser(BaseParser):
         """
 
         # run a subprocess and put the stdout and stderr on the pipe object
-        if sys.platform == 'win32':
+        if sys.platform == "win32":
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
         else:


### PR DESCRIPTION
Fixes: #51
Closes: #288 - CLI arg pass-through not needed with LibreOffice because output is paragraph style for this specific request (on the broader technical change we don't seem to need passthrough yet and I would like to avoid that coupling)
Fixes: #367 - same user request as #288
Fixes: #213 - LibreOffice is more robust with .doc file headers
Closes: #189 - LibreOffice should be more robust, but haven't tested to confirm
Closes: #444 - since the issue was submitted, the error messages and path logic have been improved across OSes
Fixes: #468

After a lot of research, LibreOffice is the best maintained option for converting .doc to other formats. Because it is ~1GB and .doc is almost 25 years out of date, I've documented both a workaround to batch process before handing off to textract and made LibreOffic optional (in both local usage and CI)