### PR TITLE
test: resolve false positive warnings & add optional pre-commit

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,7 +7,7 @@ SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build
 APIDOC        = sphinx-apidoc
-TEXTRACT      = 
+TEXTRACT      =
 APIDOC_IGNORE = ../textract/colors.py
 
 # User-friendly check for sphinx-build

--- a/docs/command_line_interface.rst
+++ b/docs/command_line_interface.rst
@@ -11,7 +11,7 @@ textract
    :func: get_parser
    :prog: textract
 
-.. note:: 
+.. note::
 
     To make the command line interface as usable as possible,
     autocompletion of available options with textract is enabled by

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -217,6 +217,26 @@ Install system dependencies (Windows, using `Chocolatey <https://chocolatey.org/
    <https://github.com/deanmalmgren/textract/blob/master/.github/actions/setup/action.yml>`_.
 
 
+Optional: pre-commit checks with hk
+------------------------------------
+
+This isn't required to contribute, but you can install `hk <https://hk.jdx.dev/>`_ to run the
+same ``ruff``, ``ruff format``, and ``pyright`` checks (defined in ``hk.pkl``) automatically as
+git hooks, instead of running ``make lint``/``make fix`` by hand.
+
+hk is installed via `mise <https://mise.jdx.dev/>`_:
+
+.. code-block:: bash
+
+    curl https://mise.run | sh
+    mise use -g hk
+    hk install --mise
+
+``hk install --mise`` wires up the git hooks and tells hk to use mise to fetch any additional
+tools its steps need. Once installed, hk runs automatically on ``git commit``/``git push``; run
+it manually with ``hk check --all`` or ``hk fix --all``.
+
+
 Releasing
 ---------
 

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,0 +1,45 @@
+// Install with `hk install --mise` to ensure local tools are available
+
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
+
+min_hk_version = "1.49.0"
+
+local linters = new Mapping<String, Step> {
+    ["ruff"] = Builtins.ruff
+    ["ruff-format"] = Builtins.ruff_format
+    ["pyright"] {
+        glob = "*.py"
+        check = "uv run pyright"
+    }
+    ["check-added-large-files"] = Builtins.check_added_large_files
+    ["check-merge-conflict"] = Builtins.check_merge_conflict
+    ["check-symlinks"] = Builtins.check_symlinks
+    ["detect-private-key"] = Builtins.detect_private_key
+    // tests/ fixtures are raw output from real tools/libraries and preserve
+    // their original line endings and whitespace on purpose; don't "fix" them
+    ["mixed-line-ending"] = (Builtins.mixed_line_ending) { exclude = List("tests/**") }
+    ["trailing-whitespace"] = (Builtins.trailing_whitespace) { exclude = List("tests/**") }
+    ["python-check-ast"] = Builtins.python_check_ast
+    ["python-debug-statements"] = Builtins.python_debug_statements
+}
+
+hooks = new {
+    ["pre-commit"] {
+        fix = true    // automatically modify files with available linter fixes
+        stash = "git" // stashes unstaged changes while running fix steps
+        steps = linters
+    }
+    ["pre-push"] {
+        steps = linters
+    }
+
+    // "fix" and "check" are special steps for `hk fix` and `hk check` commands
+    ["fix"] {
+        fix = true
+        steps = linters
+    }
+    ["check"] {
+        steps = linters
+    }
+}

--- a/hk.pkl
+++ b/hk.pkl
@@ -5,9 +5,20 @@ import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtin
 
 min_hk_version = "1.49.0"
 
+// `ruff` builtin steps invoke the global `ruff` binary. Run it via `uv run`
+// instead so hk uses the version pinned in pyproject.toml, matching
+// `make lint`/`make fix` and the `uv run pyright` step below.
 local linters = new Mapping<String, Step> {
-    ["ruff"] = Builtins.ruff
-    ["ruff-format"] = Builtins.ruff_format
+    ["ruff"] {
+        glob = List("**/*.py")
+        check = "uv run ruff check {{files}}"
+        fix = "uv run ruff check --fix {{files}}"
+    }
+    ["ruff-format"] {
+        glob = List("**/*.py")
+        check_diff = "uv run ruff format --diff {{files}}"
+        fix = "uv run ruff format {{files}}"
+    }
     ["pyright"] {
         glob = "*.py"
         check = "uv run pyright"

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -1,7 +1,33 @@
+import functools
 import unittest
+import warnings
+
+from bs4 import XMLParsedAsHTMLWarning
 
 from . import base
 
 
+def _ignore_xml_as_html_warning(test_method):
+    # epub content documents are XHTML, so BeautifulSoup's lxml HTML parser
+    # correctly warns that an XML parser would be more reliable. We keep the
+    # lenient HTML parser deliberately: it recovers from the malformed markup
+    # found in real-world epubs better than the XML parser does.
+    @functools.wraps(test_method)
+    def wrapper(*args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
+            return test_method(*args, **kwargs)
+
+    return wrapper
+
+
 class EpubTestCase(base.BaseParserTestCase, unittest.TestCase):
     extension = "epub"
+
+    @_ignore_xml_as_html_warning
+    def test_raw_text_python(self):
+        super().test_raw_text_python()
+
+    @_ignore_xml_as_html_warning
+    def test_standardized_text_python(self):
+        super().test_standardized_text_python()

--- a/tests/test_xlsx.py
+++ b/tests/test_xlsx.py
@@ -1,7 +1,20 @@
 import unittest
+import warnings
 
 from . import base
 
 
 class XlsxTestCase(base.BaseParserTestCase, unittest.TestCase):
     extension = "xlsx"
+
+    def test_standardized_text_python(self):
+        # standardized_text.xlsx carries a Mac Excel 2008 "Page Layout View"
+        # (mx:PLV) view-state extension that openpyxl doesn't model and drops
+        # on load. It holds no cell data, so the warning is benign here.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Unknown extension is not supported and will be removed",
+                category=UserWarning,
+            )
+            super().test_standardized_text_python()


### PR DESCRIPTION
General housekeeping PR to address some false-positive warnings I saw in pytest

I really like pre-commit in my development workflow and as the only contributor right now, I would prefer to have hk configured. I am flexible and if more users are regularly contributing and have strong opinions on prek or others, I would be open to switching because I would prefer we all use the same tooling/process

Note: I don't think this needs an updated changelog and CI will pass once #582 is merged