### PR TITLE
ci: resolve CI failures

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -31,12 +31,6 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        # aws/tap ships preinstalled on GH macOS runners and is untrusted under
-        # Homebrew's tap-trust feature, so every brew command prints a warning
-        # and future Homebrew versions may hard-fail. It is Amazon's official
-        # tap, so trust it explicitly (|| true keeps this a no-op if a future
-        # runner image no longer preinstalls it).
-        brew trust aws/tap || true
         brew install tesseract sox lame mad ghostscript unrtf poppler
         brew install --cask libreoffice
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,22 +10,24 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install system dependencies (Ubuntu)
+    - name: Install cached system dependencies (Ubuntu)
       if: runner.os == 'Linux'
       uses: awalsh128/cache-apt-pkgs-action@v1
       with:
-        # Full libreoffice meta-package avoids a headless UNO crash seen with libreoffice-writer alone.
-        packages: tesseract-ocr sox libsox-fmt-mp3 ghostscript unrtf poppler-utils libreoffice dbus-x11
+        packages: tesseract-ocr sox libsox-fmt-mp3 ghostscript unrtf poppler-utils
         version: 1.1
 
-    - name: Configure LibreOffice for headless runs (Ubuntu)
+    - name: Install LibreOffice (Ubuntu)
       if: runner.os == 'Linux'
       shell: bash
-      # Force the "svp" headless VCL plugin; the default gtk plugin
-      # intermittently aborts with a com::sun::star::uno::RuntimeException
-      # ("Unspecified Application Error") when soffice --convert-to runs
-      # without a display.
-      run: echo "SAL_USE_VCLPLUGIN=svp" >> "$GITHUB_ENV"
+      # LibreOffice is installed directly rather than through cache-apt-pkgs-action:
+      # that action restores package files without re-running the dpkg postinst
+      # triggers (fontconfig cache, mime database, ldconfig), which leaves
+      # soffice --headless aborting intermittently on cache-hit runs with a
+      # com::sun::star::uno::RuntimeException ("Unspecified Application Error").
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libreoffice dbus-x11
 
     - name: Install system dependencies (macOS)
       if: runner.os == 'macOS'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,10 +18,25 @@ runs:
         packages: tesseract-ocr sox libsox-fmt-mp3 ghostscript unrtf poppler-utils libreoffice dbus-x11
         version: 1.1
 
+    - name: Configure LibreOffice for headless runs (Ubuntu)
+      if: runner.os == 'Linux'
+      shell: bash
+      # Force the "svp" headless VCL plugin; the default gtk plugin
+      # intermittently aborts with a com::sun::star::uno::RuntimeException
+      # ("Unspecified Application Error") when soffice --convert-to runs
+      # without a display.
+      run: echo "SAL_USE_VCLPLUGIN=svp" >> "$GITHUB_ENV"
+
     - name: Install system dependencies (macOS)
       if: runner.os == 'macOS'
       shell: bash
       run: |
+        # aws/tap ships preinstalled on GH macOS runners and is untrusted under
+        # Homebrew's tap-trust feature, so every brew command prints a warning
+        # and future Homebrew versions may hard-fail. It is Amazon's official
+        # tap, so trust it explicitly (|| true keeps this a no-op if a future
+        # runner image no longer preinstalls it).
+        brew trust aws/tap || true
         brew install tesseract sox lame mad ghostscript unrtf poppler
         brew install --cask libreoffice
 

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -38,6 +38,21 @@ jobs:
             fi
           fi
 
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+        with:
+          python-version: "3.10"
+
+      - name: Run ruff
+        run: uv run ruff check
+
+      - name: Run pyright
+        run: uv run pyright
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -77,15 +92,12 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install cx_Freeze
-        run: uv sync --group freeze
-
       - name: Build and run frozen executable smoke test
         run: uv run python tests/freeze/smoke_test.py
 
   release:
     name: Release and Publish
-    needs: [test, cx-freeze]
+    needs: [lint, test, cx-freeze]
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
     environment:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -174,25 +174,24 @@ documents.
 Headless servers and containers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-On a headless Linux host (a server, CI runner, or container with no
-display), LibreOffice occasionally aborts partway through a ``.doc``
-conversion with an error like::
+On a headless Linux host (a server, CI runner, or container without a
+display), LibreOffice may abort with an error like::
 
     terminate called after throwing an instance of 'com::sun::star::uno::RuntimeException'
     Unspecified Application Error
 
-This is a LibreOffice issue, not a textract bug: its default graphics
-plugin expects a display. Force the headless plugin by setting
+This is a LibreOffice issue, not a textract bug because the default
+graphics plugin expects a display. Force the headless plugin by setting
 ``SAL_USE_VCLPLUGIN=svp`` in the environment before running textract:
 
 .. code-block:: bash
 
     export SAL_USE_VCLPLUGIN=svp
-    textract whatever.doc
+    textract this.doc
 
 If the crash still appears intermittently, installing the full
 ``libreoffice`` package (rather than only ``libreoffice-writer``) and
-``dbus-x11`` resolves the remaining headless startup failures.
+``dbus-x11`` will likely resolve remaining headless startup failures.
 
 Reference: CI System Dependencies
 ----------------------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -171,28 +171,6 @@ Then run ``textract out/whatever.docx`` as usual. This keeps the heavier
 converter out of your extraction pipeline while still supporting legacy
 documents.
 
-Headless servers and containers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-On a headless Linux host (a server, CI runner, or container without a
-display), LibreOffice may abort with an error like::
-
-    terminate called after throwing an instance of 'com::sun::star::uno::RuntimeException'
-    Unspecified Application Error
-
-This is a LibreOffice issue, not a textract bug because the default
-graphics plugin expects a display. Force the headless plugin by setting
-``SAL_USE_VCLPLUGIN=svp`` in the environment before running textract:
-
-.. code-block:: bash
-
-    export SAL_USE_VCLPLUGIN=svp
-    textract this.doc
-
-If the crash still appears intermittently, installing the full
-``libreoffice`` package (rather than only ``libreoffice-writer``) and
-``dbus-x11`` will likely resolve remaining headless startup failures.
-
 Reference: CI System Dependencies
 ----------------------------------
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -171,6 +171,29 @@ Then run ``textract out/whatever.docx`` as usual. This keeps the heavier
 converter out of your extraction pipeline while still supporting legacy
 documents.
 
+Headless servers and containers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On a headless Linux host (a server, CI runner, or container with no
+display), LibreOffice occasionally aborts partway through a ``.doc``
+conversion with an error like::
+
+    terminate called after throwing an instance of 'com::sun::star::uno::RuntimeException'
+    Unspecified Application Error
+
+This is a LibreOffice issue, not a textract bug: its default graphics
+plugin expects a display. Force the headless plugin by setting
+``SAL_USE_VCLPLUGIN=svp`` in the environment before running textract:
+
+.. code-block:: bash
+
+    export SAL_USE_VCLPLUGIN=svp
+    textract whatever.doc
+
+If the crash still appears intermittently, installing the full
+``libreoffice`` package (rather than only ``libreoffice-writer``) and
+``dbus-x11`` resolves the remaining headless startup failures.
+
 Reference: CI System Dependencies
 ----------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ vulnerable_packages = [
     "urllib3>=2.7.0",
 ]
 
+[tool.uv]
+default-groups = ["dev", "freeze"]
+
 [tool.uv.build-backend]
 module-name = "textract"
 module-root = ""


### PR DESCRIPTION
CI Failures on #573 appear to be related to be from Linux cache not running necessary post install scripts for LibreOffice and other attempts to resolve it were red herrings

Additionally, I realized that there was a gap that pyright and ruff weren't being run in CI, but would fail locally